### PR TITLE
Parsing: change way to set custom settings

### DIFF
--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -36,6 +36,8 @@ default_arg_parser.add_argument('-c', '--config', nargs='+', metavar='FILE', des
                                 help=_('Configuration file to be used'))
 default_arg_parser.add_argument('-s', '--save', nargs='?', const=True, metavar='FILE', dest='save',
                                 help=_('Filename of file to be saved to, defaults to config file'))
+default_arg_parser.add_argument('-S', '--settings', nargs='+', metavar='SETTING', dest='settings',
+                                help=_('Arbitrary settings in the form of section.key=value'))
 default_arg_parser.add_argument('-j', '--job-count', nargs=1, type=int, metavar='INT', dest='job_count',
                                 help=_('Number of processes to be allowed to run at once'))
 default_arg_parser.add_argument('-a', '--apply-changes', nargs=1, choices=['YES', 'NO', 'ASK'], metavar='ENUM',

--- a/coalib/tests/parsing/CliParserTest.py
+++ b/coalib/tests/parsing/CliParserTest.py
@@ -10,6 +10,7 @@ class CliParserTestCase(unittest.TestCase):
     def setUp(self):
         self.test_arg_parser = argparse.ArgumentParser()
         self.test_arg_parser.add_argument('-t', nargs='+', dest='test')
+        self.test_arg_parser.add_argument('-S', '--settings', nargs='+', dest='settings')
         self.uut = CliParser(self.test_arg_parser)
 
     def dict_from_sections(self, parsed_sections):
@@ -27,8 +28,10 @@ class CliParserTestCase(unittest.TestCase):
         # regular parse
         parsed_sections = self.uut.parse(['-t', 'ignored1', 'ignored2',
                                           '-t', 'taken',
-                                          'section1.key1,section2.key2=value1,value2', 'section2.key2=only_this_value',
-                                          'invalid.=shouldnt_be_shown', '.=not_either',
+                                          '-S', 'section1.key1,section2.key2=value1,value2',
+                                          'section2.key2=only_this_value',
+                                          'invalid.=shouldnt_be_shown',
+                                          '.=not_either',
                                           '.key=only_in_default',
                                           'default_key1,default_key2=single_value',
                                           'default_key3=first_value,second_value'])
@@ -41,7 +44,7 @@ class CliParserTestCase(unittest.TestCase):
         self.assertEqual(self.dict_from_sections(self.uut.export_to_settings()), expected_dict)
 
         # additional parse
-        add_parsed_sections = self.uut.parse(['additional.key=value'])
+        add_parsed_sections = self.uut.parse(['-S', 'additional.key=value'])
         add_expected_dict = {'default': {("test", "taken"),
                                          ("key", "only_in_default"),
                                          ("default_key1", "single_value"),
@@ -54,7 +57,7 @@ class CliParserTestCase(unittest.TestCase):
         self.assertEqual(self.dict_from_sections(add_parsed_sections), add_expected_dict)
 
         # reparse
-        new_parsed_sections = self.uut.reparse(['new_key=value'])
+        new_parsed_sections = self.uut.reparse(['-S', 'new_key=value'])
         new_expected_dict = {'default': {("new_key", "value")}}
         self.assertEqual(self.dict_from_sections(new_parsed_sections), new_expected_dict)
 

--- a/coalib/tests/settings/SectionManagerTest.py
+++ b/coalib/tests/settings/SectionManagerTest.py
@@ -15,14 +15,14 @@ class SectionManagerTestCase(unittest.TestCase):
         defaults = ConfParser().parse(os.path.abspath(os.path.join(StringConstants.coalib_root, "default_coafile")))
 
         uut = SectionManager()
-        conf_sections = uut.run(arg_list=["test=5"])[0]
+        conf_sections = uut.run(arg_list=['-S', "test=5"])[0]
 
         self.assertEqual(str(conf_sections["default"]), "Default {test : 5}")
         self.assertEqual(str(conf_sections["default"].defaults), str(defaults["default"]))
 
     def test_nonexistent_file(self):
         filename = "bad.one/test\neven with bad chars in it"
-        SectionManager().run(arg_list=["config=" + filename])  # Shouldn't throw an exception
+        SectionManager().run(arg_list=['-S', "config=" + filename])  # Shouldn't throw an exception
 
         tmp = StringConstants.coalib_root
         StringConstants.coalib_root = filename
@@ -32,13 +32,13 @@ class SectionManagerTestCase(unittest.TestCase):
     def test_back_saving(self):
         filename = os.path.join(tempfile.gettempdir(), "SectionManagerTestFile")
 
-        SectionManager().run(arg_list=["save=" + filename])
+        SectionManager().run(arg_list=['-S', "save=" + filename])
 
         with open(filename, "r") as f:
             lines = f.readlines()
         self.assertEqual(["[Default]\n"], lines)
 
-        SectionManager().run(arg_list=["save=true", "config=" + filename, "test.value=5"])
+        SectionManager().run(arg_list=['-S', "save=true", "config=" + filename, "test.value=5"])
 
         with open(filename, "r") as f:
             lines = f.readlines()
@@ -49,7 +49,7 @@ class SectionManagerTestCase(unittest.TestCase):
                           "value = 5\n"], lines)
 
     def test_logging_objects(self):
-        conf_sections, n, m = SectionManager().run(arg_list=["log_type=none"])
+        conf_sections, n, m = SectionManager().run(arg_list=['-S', "log_type=none"])
         self.assertIsInstance(conf_sections["default"].log_printer, NullPrinter)
 
 


### PR DESCRIPTION
* Settings can now be specified with the parameter --settings (-S)
* Settings can still be of the form section.key=value
* Settings can not be mixed with traditional params anymore