### PR TITLE
Correct shebang

### DIFF
--- a/coala
+++ b/coala
@@ -1,4 +1,4 @@
-#! /bin/python3
+#!/usr/bin/env python3
 
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published by the

--- a/execute_all_tests.py
+++ b/execute_all_tests.py
@@ -1,4 +1,4 @@
-#! /bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#! /bin/python3
+#!/usr/bin/env python3
 
 from distutils.core import setup
 from distutils.sysconfig import get_python_lib


### PR DESCRIPTION
According to several sources it is more platform independent to invoke
python via /usr/bin/env.

Please try it out and report if it works on your distribution!