### PR TITLE
tests: Shorten output

### DIFF
--- a/coalib/tests/TestHelper.py
+++ b/coalib/tests/TestHelper.py
@@ -13,35 +13,48 @@ class TestHelper:
             pass
 
     @staticmethod
-    def execute_python3_file(filename, use_coverage, ignored_files):
+    def print_output(command_array, verbose):
+        p = subprocess.Popen(command_array, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        retval = p.wait()
+        if retval != 0 or verbose:
+            for line in p.stderr:
+                print(line, end='')
+            for line in p.stdout:
+                print(line, end='')
+
+        return retval
+
+    @staticmethod
+    def execute_python3_file(filename, use_coverage, ignored_files, verbose):
         if sys.platform.startswith("win"):
             # On windows we won't find a python3 executable and we don't measure coverage
-            return subprocess.call(["python", filename])
+            return TestHelper.print_output(["python", filename], verbose)
 
         if not use_coverage:
-            return subprocess.call(["python3", filename])
+            return TestHelper.print_output(["python3", filename], verbose)
 
         try:
-            return subprocess.call(["coverage3",
-                                    "run",
-                                    "-p",  # make it collectable later
-                                    "--branch",  # check branch AND statement coverage
-                                    "--omit",
-                                    ignored_files,
-                                    filename])
+            return TestHelper.print_output(["coverage3",
+                                            "run",
+                                            "-p",  # make it collectable later
+                                            "--branch",  # check branch AND statement coverage
+                                            "--omit",
+                                            ignored_files,
+                                            filename], verbose)
         except:
             print("Coverage failed. Falling back to standard unit tests.")
             return subprocess.call(["python3", filename])
 
     @staticmethod
-    def execute_python3_files(filenames, use_coverage, ignore_list):
+    def execute_python3_files(filenames, use_coverage, ignore_list, verbose=False):
         number = len(filenames)
         failures = 0
-        for file in filenames:
-            print("\nRunning: {} ({})\n".format(os.path.splitext(os.path.basename(file))[0], file), end='')
-            result = TestHelper.execute_python3_file(file, use_coverage, ",".join(ignore_list))  # either 0 or 1
+        for i, file in enumerate(filenames):
+            print(" {:>2}/{:<2} | {}".format(i+1, number, os.path.splitext(os.path.basename(file))[0]))
+            result = TestHelper.execute_python3_file(file, use_coverage, ",".join(ignore_list), verbose)  # either 0 or 1
             failures += result
-            print("\n" + "#" * 70)
+            if verbose or result != 0:
+                print("#" * 70)
 
         print("\nTests finished: failures in {} of {} test modules".format(failures, number))
 

--- a/coalib/tests/collecting/BearCollectorTest.py
+++ b/coalib/tests/collecting/BearCollectorTest.py
@@ -50,6 +50,7 @@ class TestFileCollection(unittest.TestCase):
         os.close(self.testfile1)
         os.close(self.testfile2)
         os.close(self.testfile3)
+        os.close(self.testfile4)
         first_file_name = os.path.splitext(os.path.basename(self.testfile1_path))[0]
         test_bear_file_string_one = """
 from coalib.bears.Bear import Bear

--- a/coalib/tests/settings/SettingTest.py
+++ b/coalib/tests/settings/SettingTest.py
@@ -26,7 +26,8 @@ class SettingTestCase(unittest.TestCase):
 
     def test_path_list(self):
         abspath = os.path.abspath(".")
-        self.uut = Setting("key", "., " + abspath, origin="test" + os.path.sep + "somefile")
+        # Need to escape backslashes since we use list conversion
+        self.uut = Setting("key", "., " + abspath.replace("\\", "\\\\"), origin="test" + os.path.sep + "somefile")
         self.assertEqual(path_list(self.uut), [os.path.abspath(os.path.join("test", ".")), abspath])
 
     def test_inherited_conversions(self):

--- a/execute_all_tests.py
+++ b/execute_all_tests.py
@@ -24,6 +24,7 @@ if __name__ == '__main__':
     parser.add_argument("-c", "--cover", help="measure code coverage", action="store_true")
     parser.add_argument("-b", "--ignore-bear-tests", help="ignore bear tests", action="store_true")
     parser.add_argument("-m", "--ignore-main-tests", help="ignore main program tests", action="store_true")
+    parser.add_argument("-v", "--verbose", help="more verbose output", action="store_true")
     args = parser.parse_args()
 
     files = []
@@ -38,4 +39,4 @@ if __name__ == '__main__':
         os.path.join(get_python_lib(), "*")
     ])
 
-    exit(TestHelper.execute_python3_files(files, args.cover, ignore_list))
+    exit(TestHelper.execute_python3_files(files, args.cover, ignore_list, args.verbose))


### PR DESCRIPTION
One can get verbose output through passing the -v argument. If this
doesn't meet your needs because you need the ordering between
stderr/stdout you are encouraged to execute your test manually for
debugging.