### PR TITLE
Diff: Fix multiple line handling.

### DIFF
--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -33,7 +33,8 @@ class Diff:
         for change_group in matcher.get_grouped_opcodes(1):
             for tag, a_index_1, a_index_2, b_index_1, b_index_2 in change_group:
                 if tag == "delete":
-                    result.delete_line(a_index_1+1)
+                    for index in range(a_index_1+1, a_index_2+1):
+                        result.delete_line(index)
                 elif tag == "insert":
                     # We add after line, they add before, so dont add 1 here
                     result.add_lines(a_index_1,

--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -45,6 +45,8 @@ class Diff:
                                        file_array_2[b_index_1])
                     result.add_lines(a_index_1+1,
                                      file_array_2[b_index_1+1:b_index_2])
+                    for index in range(a_index_1+2, a_index_2+1):
+                        result.delete_line(index)
 
         return result
 

--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -42,6 +42,8 @@ class Diff:
                     result.change_line(a_index_1+1,
                                        b_index_1+1,
                                        file_array_2[b_index_1])
+                    result.add_lines(a_index_1+1,
+                                     file_array_2[b_index_1+1:b_index_2])
 
         return result
 

--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -36,7 +36,8 @@ class Diff:
                     result.delete_line(a_index_1+1)
                 elif tag == "insert":
                     # We add after line, they add before, so dont add 1 here
-                    result.add_lines(a_index_1, [file_array_2[b_index_1]])
+                    result.add_lines(a_index_1,
+                                     file_array_2[b_index_1:b_index_2])
                 elif tag == "replace":
                     result.change_line(a_index_1+1,
                                        b_index_1+1,

--- a/coalib/tests/results/DiffTest.py
+++ b/coalib/tests/results/DiffTest.py
@@ -104,6 +104,11 @@ class DiffTestCase(unittest.TestCase):
         self.uut = Diff.from_string_arrays(a, b)
         self.assertEqual(self.uut.apply(a), b)
 
+        a = ["first", "second", "third", "fourth"]
+        b = ["first_changed", "second_changed", "fourth"]
+        self.uut = Diff.from_string_arrays(a, b)
+        self.assertEqual(self.uut.apply(a), b)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/coalib/tests/results/DiffTest.py
+++ b/coalib/tests/results/DiffTest.py
@@ -87,7 +87,11 @@ class DiffTestCase(unittest.TestCase):
         a = ["q", "a", "b", "x", "c", "d"]
         b = ["a", "b", "y", "c", "d", "f"]
         self.uut = Diff.from_string_arrays(a, b)
+        self.assertEqual(self.uut.apply(a), b)
 
+        a = ["first", "fourth"]
+        b = ["first", "second", "third", "fourth"]
+        self.uut = Diff.from_string_arrays(a, b)
         self.assertEqual(self.uut.apply(a), b)
 
 

--- a/coalib/tests/results/DiffTest.py
+++ b/coalib/tests/results/DiffTest.py
@@ -94,6 +94,11 @@ class DiffTestCase(unittest.TestCase):
         self.uut = Diff.from_string_arrays(a, b)
         self.assertEqual(self.uut.apply(a), b)
 
+        a = ["first", "fourth"]
+        b = ["first_changed", "second", "third", "fourth"]
+        self.uut = Diff.from_string_arrays(a, b)
+        self.assertEqual(self.uut.apply(a), b)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/coalib/tests/results/DiffTest.py
+++ b/coalib/tests/results/DiffTest.py
@@ -99,6 +99,11 @@ class DiffTestCase(unittest.TestCase):
         self.uut = Diff.from_string_arrays(a, b)
         self.assertEqual(self.uut.apply(a), b)
 
+        a = ["first", "second", "third", "fourth"]
+        b = ["first", "fourth"]
+        self.uut = Diff.from_string_arrays(a, b)
+        self.assertEqual(self.uut.apply(a), b)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
We do matcher.get_grouped_opcodes(1) and assume that each change group
affects only one line in the origin and target file. However despit it
may affect only one origin line it may affect several target lines thus
we need to remove that assumption.

Fixes: https://github.com/coala-analyzer/coala/issues/316