### PR TITLE
Escaping functions

### DIFF
--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -67,7 +67,7 @@ def escaped_split(pattern,
     # if we try to match the escape sequences too, they would be replaced,
     # because they are consumed then by the regex. That's not wanted.
     match_strings = []
-    matches = search_for(r"(.*?)(?<!\\)((?:\\\\)*)(?:" + pattern + ")",
+    matches = search_for(r"(.*?)(?<!\\)((?:\\\\)*)(?:" + pattern + r")",
                          string,
                          max_split,
                          re.DOTALL)
@@ -131,7 +131,7 @@ def unescaped_search_in_between(begin,
     # The found matches are placed inside this variable.
     match_strings = []
 
-    for item in search_for(begin + r"(.*?)" + end,
+    for item in search_for("(?:" + begin + r")(.*?)(?:" + end + r")",
                            string,
                            max_matches,
                            re.DOTALL):
@@ -177,8 +177,8 @@ def escaped_search_in_between(begin,
     rxc_begin = re.compile(begin)
 
     match_strings = []
-    for item in search_for(r"(?<!\\)(?:\\\\)*" + begin +
-                               r"(.*?)(?<!\\)((?:\\\\)*)" + end,
+    for item in search_for(r"(?<!\\)(?:\\\\)*(?:" + begin +
+                               r")(.*?)(?<!\\)((?:\\\\)*)(?:" + end + r")",
                            string,
                            max_matches,
                            re.DOTALL):

--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -67,7 +67,7 @@ def escaped_split(pattern,
     # if we try to match the escape sequences too, they would be replaced,
     # because they are consumed then by the regex. That's not wanted.
     match_strings = []
-    matches = search_for(r"(.*?)(?<!\\)((?:\\\\)*)" + pattern,
+    matches = search_for(r"(.*?)(?<!\\)((?:\\\\)*)(?:" + pattern + ")",
                          string,
                          max_split,
                          re.DOTALL)

--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -5,7 +5,8 @@ def unescaped_split(pattern,
                     max_split = 0,
                     remove_empty_matches = False):
     """
-    Splits the given string by the specified pattern.
+    Splits the given string by the specified pattern. The return character (\n)
+    is not a natural split pattern (if you don't specify it yourself).
     :param pattern:              The pattern that defines where to split.
                                  Providing regexes (and not only fixed strings)
                                  is allowed.
@@ -23,7 +24,7 @@ def unescaped_split(pattern,
     """
 
     # Split the string with the built-in function re.split().
-    match = re.split(pattern, string, max_split)
+    match = re.split(pattern, string, max_split, re.DOTALL)
 
     # If empty entries shall be removed, apply a filter and recollect all
     # non-empty values with the passed iterator.

--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -97,6 +97,47 @@ def escaped_split(pattern,
 
     return match_strings
 
+def unescaped_search_in_between(begin, end, string, max_matches = 0):
+    """
+    Searches for a string enclosed between a specified begin- and end-sequence.
+    Also enclosed \n are put into the result. Doesn't handle escape sequences.
+    :param begin:                The begin-sequence where to start matching.
+                                 Providing regexes (and not only fixed strings)
+                                 is allowed.
+    :param end:                  The end-sequence where to end matching.
+                                 Providing regexes (and not only fixed strings)
+                                 is allowed.
+    :param string:               The string where to search in.
+    :param max_matches           Optional. Defines the number of matches this
+                                 function performs. If 0 is provided, unlimited
+                                 matches are made. If a number bigger than 0 is
+                                 passed, this functions only matches
+                                 max_matches-times and appends the unprocessed
+                                 rest of the string to the result. A negative
+                                 number won't perform any matches.
+    :param remove_empty_matches: Optional. defines whether empty entries should
+                                 be removed from the resulting list.
+    :return:                     A list containing the matched strings.
+    """
+
+    # Compilation of the begin sequence is needed to get the number of
+    # capturing groups in it.
+    rxc_begin = re.compile(begin)
+
+    # The found matches are placed inside this variable.
+    match_strings = []
+
+    for item in search_for(begin + r"(.*?)" + end,
+                           string,
+                           max_matches,
+                           re.DOTALL):
+        # If a user provides a pattern with a matching group (concrete a
+        # pattern with a capturing group in parantheses "()"), we need to
+        # return the right one. That's why we compiled the begin-sequence
+        # before.
+        match_strings.append(item.group(rxc_begin.groups + 1))
+    return match_strings
+
 def search_for(pattern, string, max_matches = 0, flags = 0):
     """
     Searches for a given pattern in a string max_matches-times.

--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -1,0 +1,37 @@
+import re
+
+def unescaped_split(pattern,
+                    string,
+                    max_split = 0,
+                    remove_empty_matches = False):
+    """
+    Splits the given string by the specified pattern.
+    :param pattern:              The pattern that defines where to split.
+                                 Providing regexes (and not only fixed strings)
+                                 is allowed.
+    :param string:               The string to split by the defined pattern.
+    :param max_split:            Optional. Defines the number of splits this
+                                 function performs. If 0 is provided, unlimited
+                                 splits are made. If a number bigger than 0 is
+                                 passed, this functions only splits
+                                 max_split-times and appends the unprocessed
+                                 rest of the string to the result. A negative
+                                 number won't perform any splits.
+    :param remove_empty_matches: Optional. defines whether empty entries should
+                                 be removed from the resulting list.
+    :return:                     A list containing the split up strings.
+    """
+
+    # Split the string with the built-in function re.split().
+    match = re.split(pattern, string, max_split)
+
+    # If empty entries shall be removed, apply a filter and recollect all
+    # non-empty values with the passed iterator.
+    if (remove_empty_matches):
+        filtered_match = filter(bool, match)
+        match = []
+        for item in filtered_match:
+            match.append(item)
+
+    return match
+

--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -95,17 +95,22 @@ def escaped_split(pattern,
     last_pos = 0
     # Process each returned MatchObject.
     for item in matches:
-        if (not remove_empty_matches or len(item.group(1)) != 0):
-            # Return the first matching group. The pattern from parameter can't
-            # change the group order.
-            match_strings.append(item.group(1))
-            # Concat it with the second group, that contains all escapes that
-            # are escaped and would get consumed.
-            if (item.group(2) is not None):
-                match_strings[-1] += item.group(2)
+        # Use a temporary concatenation string to check at last if it's empty.
+        concat_string = item.group(1)
 
-            # Update the end position.
-            last_pos = item.end()
+        if (item.group(2) is not None):
+            # If escaped escapes were consumed from the second group, append
+            # them too.
+            concat_string += item.group(2)
+
+        # If our temporary concatenation string is empty and the
+        # remove_empty_matches flag is specified, don't append it to the
+        # result.
+        if (not remove_empty_matches or len(concat_string) != 0):
+            match_strings.append(concat_string)
+
+        # Update the end position.
+        last_pos = item.end()
 
     # Append the rest of the string, since it's not in the result list (only
     # matches are captured that have a leading separator).

--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -36,3 +36,41 @@ def unescaped_split(pattern,
 
     return match
 
+def search_for(pattern, string, max_matches = 0, flags = 0):
+    """
+    Searches for a given pattern in a string max_matches-times.
+    :param pattern:     The pattern to search for. Providing regexes (and not
+                        only fixed strings) is allowed.
+    :param string:      The string to search in.
+    :param max_matches: Optional. The maximum number of matches to perform.
+    :param flags:       Optional. Additional flags to pass to the regex
+                        processor.
+    """
+    if (max_matches == 0):
+        # Use plain re.finditer() to find all matches.
+        return re.finditer(pattern, string, flags)
+    elif (max_matches > 0):
+        # Compile the regex expression to gain performance.
+        rxc = re.compile(pattern, flags)
+        # The in-string position that indicates the beginning of the regex
+        # processing.
+        pos = 0
+
+        matches = []
+        for x in range(0, max_matches):
+            current_match = rxc.search(string, pos)
+
+            if (current_match is None):
+                # Break out, no more matches found.
+                break
+            else:
+                # Else, append the found match to the match list.
+                matches.append(current_match)
+                # Update the in-string position.
+                pos = current_match.end()
+
+        return matches
+    else:
+        # Return the unprocessed string.
+        return string
+

--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -97,7 +97,11 @@ def escaped_split(pattern,
 
     return match_strings
 
-def unescaped_search_in_between(begin, end, string, max_matches = 0):
+def unescaped_search_in_between(begin,
+                                end,
+                                string,
+                                max_matches = 0,
+                                remove_empty_matches = False):
     """
     Searches for a string enclosed between a specified begin- and end-sequence.
     Also enclosed \n are put into the result. Doesn't handle escape sequences.
@@ -135,7 +139,9 @@ def unescaped_search_in_between(begin, end, string, max_matches = 0):
         # pattern with a capturing group in parantheses "()"), we need to
         # return the right one. That's why we compiled the begin-sequence
         # before.
-        match_strings.append(item.group(rxc_begin.groups + 1))
+        if (not remove_empty_matches or
+                len(item.group(rxc_begin.groups + 1)) != 0):
+            match_strings.append(item.group(rxc_begin.groups + 1))
     return match_strings
 
 def search_for(pattern, string, max_matches = 0, flags = 0):

--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -61,6 +61,9 @@ def escaped_split(pattern,
     Splits the given string by the specified pattern. The return character (\n)
     is not a natural split pattern (if you don't specify it yourself).
     This function handles escaped split-patterns.
+    CAUTION: Using the escaped character '\' itself in the pattern the function
+             can return strange results. The backslash can interfere with the
+             escaping regex-sequence used internally to split.
     :param pattern:              The pattern that defines where to split.
                                  Providing regexes (and not only fixed strings)
                                  is allowed.
@@ -175,6 +178,10 @@ def escaped_search_in_between(begin,
     Searches for a string enclosed between a specified begin- and end-sequence.
     Also enclosed \n are put into the result.
     Handles escaped begin- and end-sequences.
+    CAUTION: Using the escaped character '\' itself in the begin- or
+             end-sequences the function can return strange results. The
+             backslash can interfere with the escaping regex-sequence used
+             internally to match the enclosed string.
     :param begin:                The begin-sequence where to start matching.
                                  Providing regexes (and not only fixed strings)
                                  is allowed.

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -1,0 +1,62 @@
+import sys
+sys.path.insert(0, ".")
+import unittest
+
+from coalib.parsing.StringProcessing import *
+
+class StringProcessingTest(unittest.TestCase):
+    def setUp(self):
+        self.test_strings = [
+            r"out1 'escaped-escape:        \\ ' out2",
+            r"out1 'escaped-quote:         \' ' out2",
+            r"out1 'escaped-anything:      \X ' out2",
+            r"out1 'two escaped escapes: \\\\ ' out2",
+            r"out1 'escaped-quote at end:   \'' out2",
+            r"out1 'escaped-escape at end:  \\' out2",
+            r"out1           'str1' out2 'str2' out2",
+            r"out1 \'        'str1' out2 'str2' out2",
+            r"out1 \\\'      'str1' out2 'str2' out2",
+            r"out1 \\        'str1' out2 'str2' out2",
+            r"out1 \\\\      'str1' out2 'str2' out2",
+            r"out1         \\'str1' out2 'str2' out2",
+            r"out1       \\\\'str1' out2 'str2' out2",
+            r"out1           'str1''str2''str3' out2"]
+
+        # The backslash character. Needed since there are limitations when
+        # using backslashes at the end of raw-strings in front of the
+        # terminating " or '.
+        self.bs = "\\"
+
+    # Test the basic unescaped_split() functionality.
+    def test_unescaped_split(self):
+        separator_pattern = "'"
+        expected_results = [
+            [r"out1 ", r"escaped-escape:        \\ ", r" out2"],
+            [r"out1 ", r"escaped-quote:         " + self.bs, r" ", r" out2"],
+            [r"out1 ", r"escaped-anything:      \X ", r" out2"],
+            [r"out1 ", r"two escaped escapes: \\\\ ", r" out2"],
+            [r"out1 ", r"escaped-quote at end:   " + self.bs, r"", r" out2"],
+            [r"out1 ", r"escaped-escape at end:  " + 2 * self.bs, r" out2"],
+            [r"out1           ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 " + self.bs, r"        ", r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1 " + 3 * self.bs, r"      ", r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1 \\        ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \\\\      ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1         " + 2 * self.bs, r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1       " + 4 * self.bs, r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1           ", r"str1", r"", r"str2", r"", r"str3", r" out2"]
+        ]
+
+        for i in range(0, len(self.test_strings)):
+            # Execute function under test.
+            return_value = unescaped_split(separator_pattern,
+                                           self.test_strings[i])
+            self.assertEqual(expected_results[i], return_value)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)
+

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -51,7 +51,7 @@ class StringProcessingTest(unittest.TestCase):
             [r"out1           ", r"str1", r"", r"str2", r"", r"str3", r" out2"]
         ]
 
-        for i in range(0, len(self.test_strings)):
+        for i in range(0, len(expected_results)):
             # Execute function under test.
             return_value = unescaped_split(separator_pattern,
                                            self.test_strings[i])

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -29,7 +29,7 @@ class StringProcessingTest(unittest.TestCase):
 
         # Test string for multi-pattern tests (since we want to variate the
         # pattern, not the test string).
-        self.multi_pattern_test_string = (r"abcabccba###\\13ß4ujsabbc\+'**'ac"
+        self.multi_pattern_test_string = (r"abcabccba###\\13q4ujsabbc\+'**'ac"
                                           r"###.#.####-ba")
 
         # Multiple patterns for the multi-pattern tests.
@@ -171,15 +171,15 @@ class StringProcessingTest(unittest.TestCase):
     # Test the unescaped_split() function with different regex patterns.
     def test_unescaped_split_regex_pattern(self):
         expected_results = [
-            [r"", r"", r"cba###\\13ß4ujsabbc\+'**'ac###.#.####-ba"],
-            [r"", r"c", r"ccba###\\13ß4ujs", r"bc\+'**'ac###.#.####-ba"],
-            [r"", r"c", r"ccba###\\13ß4ujs", r"bc\+'**'", r"###.#.####-ba"],
-            [r"abcabccba###", r"", r"13ß4ujsabbc", r"+'**'ac###.#.####-ba"],
-            [r"abcabccba", r"\\13ß4ujsabbc\+'**'ac", r".", r".", r"-ba"],
-            [r"", r"", r"c", r"", r"cc", r"", r"", r"", r"\13ß4ujs", r"", r"",
+            [r"", r"", r"cba###\\13q4ujsabbc\+'**'ac###.#.####-ba"],
+            [r"", r"c", r"ccba###\\13q4ujs", r"bc\+'**'ac###.#.####-ba"],
+            [r"", r"c", r"ccba###\\13q4ujs", r"bc\+'**'", r"###.#.####-ba"],
+            [r"abcabccba###", r"", r"13q4ujsabbc", r"+'**'ac###.#.####-ba"],
+            [r"abcabccba", r"\\13q4ujsabbc\+'**'ac", r".", r".", r"-ba"],
+            [r"", r"", r"c", r"", r"cc", r"", r"", r"", r"\13q4ujs", r"", r"",
                 r"c\+'**'", r"c", r"", r"", r"", r"", r"-", r"", r""],
-            [r"", r"cba###\\13ß4ujs", r"\+'**'", r"###.#.####-ba"],
-            [r"abcabccba###" + 2 * self.bs, r"3ß4ujsabbc" + self.bs,
+            [r"", r"cba###\\13q4ujs", r"\+'**'", r"###.#.####-ba"],
+            [r"abcabccba###" + 2 * self.bs, r"3q4ujsabbc" + self.bs,
                 r"'**'ac###.#.####-ba"]
         ]
 
@@ -326,15 +326,15 @@ class StringProcessingTest(unittest.TestCase):
     # Test the escaped_split() function with different regex patterns.
     def test_escaped_split_regex_pattern(self):
         expected_results = [
-            [r"", r"", r"cba###\\13ß4ujsabbc\+'**'ac###.#.####-ba"],
-            [r"", r"c", r"ccba###\\13ß4ujs", r"bc\+'**'ac###.#.####-ba"],
-            [r"", r"c", r"ccba###\\13ß4ujs", r"bc\+'**'", r"###.#.####-ba"],
-            [r"abcabccba###", r"\13ß4ujsabbc", r"+'**'ac###.#.####-ba"],
-            [r"abcabccba", r"\\13ß4ujsabbc\+'**'ac", r".", r".", r"-ba"],
-            [r"", r"", r"c", r"", r"cc", r"", r"", r"", r"\13ß4ujs", r"", r"",
+            [r"", r"", r"cba###\\13q4ujsabbc\+'**'ac###.#.####-ba"],
+            [r"", r"c", r"ccba###\\13q4ujs", r"bc\+'**'ac###.#.####-ba"],
+            [r"", r"c", r"ccba###\\13q4ujs", r"bc\+'**'", r"###.#.####-ba"],
+            [r"abcabccba###", r"\13q4ujsabbc", r"+'**'ac###.#.####-ba"],
+            [r"abcabccba", r"\\13q4ujsabbc\+'**'ac", r".", r".", r"-ba"],
+            [r"", r"", r"c", r"", r"cc", r"", r"", r"", r"\13q4ujs", r"", r"",
                 r"c\+'**'", r"c", r"", r"", r"", r"", r"-", r"", r""],
-            [r"", r"cba###\\13ß4ujs", r"\+'**'", r"###.#.####-ba"],
-            [r"abcabccba###" + 2 * self.bs, r"3ß4ujsabbc\+'**'ac###.#.####-ba"]
+            [r"", r"cba###\\13q4ujs", r"\+'**'", r"###.#.####-ba"],
+            [r"abcabccba###" + 2 * self.bs, r"3q4ujsabbc\+'**'ac###.#.####-ba"]
         ]
 
         for i in range(0, len(expected_results)):
@@ -484,10 +484,10 @@ class StringProcessingTest(unittest.TestCase):
             [r"c"],
             [r"c", r"bc\+'**'"],
             [r""],
-            [r"\\13ß4ujsabbc\+'**'ac", r"."],
+            [r"\\13q4ujsabbc\+'**'ac", r"."],
             [r"", r"", r"", r"", r"", r"c\+'**'", r"", r"", r"-"],
-            [r"cba###\\13ß4ujs"],
-            [r"3ß4ujsabbc" + self.bs]
+            [r"cba###\\13q4ujs"],
+            [r"3q4ujsabbc" + self.bs]
         ]
 
         for i in range(0, len(expected_results)):

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -507,6 +507,93 @@ class StringProcessingTest(unittest.TestCase):
                                                      self.test_strings[i])
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the secaped_search_in_between() while variating the max_match
+    # parameter.
+    def test_escaped_search_in_between_max_match(self):
+        begin_sequence = "'"
+        end_sequence = "'"
+
+        # Testing max_match = 1
+        max_match = 1
+        expected_results = [
+            [r"escaped-escape:        \\ "],
+            [r"escaped-quote:         \' "],
+            [r"escaped-anything:      \X "],
+            [r"two escaped escapes: \\\\ "],
+            [r"escaped-quote at end:   \'"],
+            [r"escaped-escape at end:  " + 2 * self.bs],
+            [r"str1"],
+            [r"str1"],
+            [r"str1"],
+            [r"str1"],
+            [r"str1"],
+            [r"str1"],
+            [r"str1"],
+            [r"str1"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = escaped_search_in_between(begin_sequence,
+                                                     end_sequence,
+                                                     self.test_strings[i],
+                                                     max_match)
+            self.assertEqual(expected_results[i], return_value)
+
+        # Testing max_match = 2
+        max_match = 2
+        expected_results = [
+            [r"escaped-escape:        \\ "],
+            [r"escaped-quote:         \' "],
+            [r"escaped-anything:      \X "],
+            [r"two escaped escapes: \\\\ "],
+            [r"escaped-quote at end:   \'"],
+            [r"escaped-escape at end:  " + 2 * self.bs],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = escaped_search_in_between(begin_sequence,
+                                                     end_sequence,
+                                                     self.test_strings[i],
+                                                     max_match)
+            self.assertEqual(expected_results[i], return_value)
+
+        # Testing max_match = 10
+        max_match = 10
+        expected_results = [
+            [r"escaped-escape:        \\ "],
+            [r"escaped-quote:         \' "],
+            [r"escaped-anything:      \X "],
+            [r"two escaped escapes: \\\\ "],
+            [r"escaped-quote at end:   \'"],
+            [r"escaped-escape at end:  " + 2 * self.bs],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2", r"str3"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = escaped_search_in_between(begin_sequence,
+                                                     end_sequence,
+                                                     self.test_strings[i],
+                                                     max_match)
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the search_for() function.
     def test_search_for(self):
         # Match either "out1" or "out2".

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -57,6 +57,95 @@ class StringProcessingTest(unittest.TestCase):
                                            self.test_strings[i])
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the unescaped_split() function while variating the max_split
+    # parameter.
+    def test_unescaped_split_max_split(self):
+        separator_pattern = "'"
+
+        # Testing max_split = 1.
+        max_split = 1
+        expected_results = [
+            [r"out1 ", r"escaped-escape:        \\ ' out2"],
+            [r"out1 ", r"escaped-quote:         \' ' out2"],
+            [r"out1 ", r"escaped-anything:      \X ' out2"],
+            [r"out1 ", r"two escaped escapes: \\\\ ' out2"],
+            [r"out1 ", r"escaped-quote at end:   \'' out2"],
+            [r"out1 ", r"escaped-escape at end:  \\' out2"],
+            [r"out1           ", r"str1' out2 'str2' out2"],
+            [r"out1 " + self.bs, r"        'str1' out2 'str2' out2"],
+            [r"out1 " + 3 * self.bs, r"      'str1' out2 'str2' out2"],
+            [r"out1 \\        ", r"str1' out2 'str2' out2"],
+            [r"out1 \\\\      ", r"str1' out2 'str2' out2"],
+            [r"out1         " + 2 * self.bs, r"str1' out2 'str2' out2"],
+            [r"out1       " + 4 * self.bs, r"str1' out2 'str2' out2"],
+            [r"out1           ", r"str1''str2''str3' out2"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = unescaped_split(separator_pattern,
+                                           self.test_strings[i],
+                                           max_split)
+            self.assertEqual(expected_results[i], return_value)
+
+        # Testing max_split = 2.
+        max_split = 2
+        expected_results = [
+            [r"out1 ", r"escaped-escape:        \\ ", r" out2"],
+            [r"out1 ", r"escaped-quote:         " + self.bs, r" ' out2"],
+            [r"out1 ", r"escaped-anything:      \X ", r" out2"],
+            [r"out1 ", r"two escaped escapes: \\\\ ", r" out2"],
+            [r"out1 ", r"escaped-quote at end:   " + self.bs, r"' out2"],
+            [r"out1 ", r"escaped-escape at end:  " + 2 * self.bs, r" out2"],
+            [r"out1           ", r"str1", r" out2 'str2' out2"],
+            [r"out1 " + self.bs, r"        ", r"str1' out2 'str2' out2"],
+            [r"out1 " + 3 * self.bs, r"      ", r"str1' out2 'str2' out2"],
+            [r"out1 \\        ", r"str1", r" out2 'str2' out2"],
+            [r"out1 \\\\      ", r"str1", r" out2 'str2' out2"],
+            [r"out1         " + 2 * self.bs, r"str1", r" out2 'str2' out2"],
+            [r"out1       " + 4 * self.bs, r"str1", r" out2 'str2' out2"],
+            [r"out1           ", r"str1", r"'str2''str3' out2"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = unescaped_split(separator_pattern,
+                                           self.test_strings[i],
+                                           max_split)
+            self.assertEqual(expected_results[i], return_value)
+
+        # Testing max_split = 10.
+        # For the given test string this result should be equal with defining
+        # max_split = 0, since we haven't 10 separators in a test string.
+        max_split = 10
+        expected_results = [
+            [r"out1 ", r"escaped-escape:        \\ ", r" out2"],
+            [r"out1 ", r"escaped-quote:         " + self.bs, r" ", r" out2"],
+            [r"out1 ", r"escaped-anything:      \X ", r" out2"],
+            [r"out1 ", r"two escaped escapes: \\\\ ", r" out2"],
+            [r"out1 ", r"escaped-quote at end:   " + self.bs, r"", r" out2"],
+            [r"out1 ", r"escaped-escape at end:  " + 2 * self.bs, r" out2"],
+            [r"out1           ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 " + self.bs, r"        ", r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1 " + 3 * self.bs, r"      ", r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1 \\        ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \\\\      ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1         " + 2 * self.bs, r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1       " + 4 * self.bs, r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1           ", r"str1", r"", r"str2", r"", r"str3", r" out2"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = unescaped_split(separator_pattern,
+                                           self.test_strings[i],
+                                           max_split)
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the basic escaped_split() functionality.
     def test_escaped_split(self):
         separator_pattern = "'"

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -499,6 +499,28 @@ class StringProcessingTest(unittest.TestCase):
                 self.multi_pattern_test_string)
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the unescaped_search_in_between() function for its
+    # remove_empty_matches feature.
+    def test_unescaped_search_in_between_auto_trim(self):
+        begin_sequence = ";"
+        end_sequence = ";"
+        expected_results = [
+            [],
+            [5 * self.bs, r"\\\'", self.bs, r"+ios"],
+            [r"2", r"4", r"6"],
+            [r"2", r"4", r"6"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = unescaped_search_in_between(
+                begin_sequence,
+                end_sequence,
+                self.auto_trim_test_strings[i],
+                0,
+                True)
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the basic escaped_search_in_between() functionality.
     def test_escaped_search_in_between(self):
         begin_sequence = "'"

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -85,6 +85,34 @@ class StringProcessingTest(unittest.TestCase):
                                          self.test_strings[i])
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the basic unescaped_search_in_between() functionality.
+    def test_unescaped_search_in_between(self):
+        begin_sequence = "'"
+        end_sequence = "'"
+        expected_results = [
+            [r"escaped-escape:        \\ "],
+            [r"escaped-quote:         " + self.bs],
+            [r"escaped-anything:      \X "],
+            [r"two escaped escapes: \\\\ "],
+            [r"escaped-quote at end:   " + self.bs],
+            [r"escaped-escape at end:  " + 2 * self.bs],
+            [r"str1", r"str2"],
+            [r"        ", r" out2 "],
+            [r"      ", r" out2 "],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2", r"str3"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = unescaped_search_in_between(begin_sequence,
+                                                       end_sequence,
+                                                       self.test_strings[i])
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the search_for() function.
     def test_search_for(self):
         # Match either "out1" or "out2".

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -174,6 +174,93 @@ class StringProcessingTest(unittest.TestCase):
                                          self.test_strings[i])
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the escaped_split() function while variating the max_split
+    # parameter.
+    def test_escaped_split_max_split(self):
+        separator_pattern = "'"
+
+        # Testing max_split = 1.
+        max_split = 1
+        expected_results = [
+            [r"out1 ", r"escaped-escape:        \\ ' out2"],
+            [r"out1 ", r"escaped-quote:         \' ' out2"],
+            [r"out1 ", r"escaped-anything:      \X ' out2"],
+            [r"out1 ", r"two escaped escapes: \\\\ ' out2"],
+            [r"out1 ", r"escaped-quote at end:   \'' out2"],
+            [r"out1 ", r"escaped-escape at end:  \\' out2"],
+            [r"out1           ", r"str1' out2 'str2' out2"],
+            [r"out1 \'        ", r"str1' out2 'str2' out2"],
+            [r"out1 \\\'      ", r"str1' out2 'str2' out2"],
+            [r"out1 \\        ", r"str1' out2 'str2' out2"],
+            [r"out1 \\\\      ", r"str1' out2 'str2' out2"],
+            [r"out1         " + 2 * self.bs, r"str1' out2 'str2' out2"],
+            [r"out1       " + 4 * self.bs, r"str1' out2 'str2' out2"],
+            [r"out1           ", r"str1''str2''str3' out2"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = escaped_split(separator_pattern,
+                                         self.test_strings[i],
+                                         max_split)
+            self.assertEqual(expected_results[i], return_value)
+
+        # Testing max_split = 2.
+        max_split = 2
+        expected_results = [
+            [r"out1 ", r"escaped-escape:        \\ ", r" out2"],
+            [r"out1 ", r"escaped-quote:         \' ", r" out2"],
+            [r"out1 ", r"escaped-anything:      \X ", r" out2"],
+            [r"out1 ", r"two escaped escapes: \\\\ ", r" out2"],
+            [r"out1 ", r"escaped-quote at end:   \'", r" out2"],
+            [r"out1 ", r"escaped-escape at end:  " + 2 * self.bs, r" out2"],
+            [r"out1           ", r"str1", r" out2 'str2' out2"],
+            [r"out1 \'        ", r"str1", r" out2 'str2' out2"],
+            [r"out1 \\\'      ", r"str1", r" out2 'str2' out2"],
+            [r"out1 \\        ", r"str1", r" out2 'str2' out2"],
+            [r"out1 \\\\      ", r"str1", r" out2 'str2' out2"],
+            [r"out1         " + 2 * self.bs, r"str1", r" out2 'str2' out2"],
+            [r"out1       " + 4 * self.bs, r"str1", r" out2 'str2' out2"],
+            [r"out1           ", r"str1", r"'str2''str3' out2"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = escaped_split(separator_pattern,
+                                         self.test_strings[i],
+                                         max_split)
+            self.assertEqual(expected_results[i], return_value)
+
+        # Testing max_split = 10.
+        # For the given test string this result should be equal with defining
+        # max_split = 0, since we haven't 10 separators in a test string.
+        max_split = 10
+        expected_results = [
+            [r"out1 ", r"escaped-escape:        \\ ", r" out2"],
+            [r"out1 ", r"escaped-quote:         \' ", r" out2"],
+            [r"out1 ", r"escaped-anything:      \X ", r" out2"],
+            [r"out1 ", r"two escaped escapes: \\\\ ", r" out2"],
+            [r"out1 ", r"escaped-quote at end:   \'", r" out2"],
+            [r"out1 ", r"escaped-escape at end:  " + 2 * self.bs, r" out2"],
+            [r"out1           ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \'        ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \\\'      ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \\        ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \\\\      ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1         " + 2 * self.bs, r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1       " + 4 * self.bs, r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1           ", r"str1", r"", r"str2", r"", r"str3", r" out2"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = escaped_split(separator_pattern,
+                                         self.test_strings[i],
+                                         max_split)
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the basic unescaped_search_in_between() functionality.
     def test_unescaped_search_in_between(self):
         begin_sequence = "'"

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -346,6 +346,24 @@ class StringProcessingTest(unittest.TestCase):
                                          self.multi_pattern_test_string)
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the escaped_split() function for its remove_empty_matches feature.
+    def test_escaped_split_auto_trim(self):
+        separator = ";"
+        expected_results = [
+            [],
+            [2 * self.bs, r"\\\\\;\\#", r"\\\'", r"\;\\\\", r"+ios"],
+            [r"1", r"2", r"3", r"4", r"5", r"6"],
+            [r"1", r"2", r"3", r"4", r"5", r"6", r"7"],
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = escaped_split(separator,
+                                         self.auto_trim_test_strings[i],
+                                         0,
+                                         True)
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the basic unescaped_search_in_between() functionality.
     def test_unescaped_search_in_between(self):
         begin_sequence = "'"

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -22,6 +22,11 @@ class StringProcessingTest(unittest.TestCase):
             r"out1       \\\\'str1' out2 'str2' out2",
             r"out1           'str1''str2''str3' out2"]
 
+        # Test string for multi-pattern tests (since we want to variate the
+        # pattern, not the test string).
+        self.multi_pattern_test_string = (r"abcabccba###\\13ß4ujsabbc\+'**'ac"
+                                          r"###.#.####-ba")
+
         # The backslash character. Needed since there are limitations when
         # using backslashes at the end of raw-strings in front of the
         # terminating " or '.
@@ -259,6 +264,34 @@ class StringProcessingTest(unittest.TestCase):
             return_value = escaped_split(separator_pattern,
                                          self.test_strings[i],
                                          max_split)
+            self.assertEqual(expected_results[i], return_value)
+
+    # Test the escaped_split() function with different regex patterns.
+    def test_escaped_split_regex_pattern(self):
+        test_patterns = [r"abc",
+                         r"ab",
+                         r"ab|ac",
+                         2 * self.bs,
+                         r"#+",
+                         r"(a)|(b)|(#.)",
+                         r"(?:a(b)*c)+",
+                         r"1|\+"]
+        expected_results = [
+            [r"", r"", r"cba###\\13ß4ujsabbc\+'**'ac###.#.####-ba"],
+            [r"", r"c", r"ccba###\\13ß4ujs", r"bc\+'**'ac###.#.####-ba"],
+            [r"", r"c", r"ccba###\\13ß4ujs", r"bc\+'**'", r"###.#.####-ba"],
+            [r"abcabccba###", r"\13ß4ujsabbc", r"+'**'ac###.#.####-ba"],
+            [r"abcabccba", r"\\13ß4ujsabbc\+'**'ac", r".", r".", r"-ba"],
+            [r"", r"", r"c", r"", r"cc", r"", r"", r"", r"\13ß4ujs", r"", r"",
+                r"c\+'**'", r"c", r"", r"", r"", r"", r"-", r"", r""],
+            [r"", r"cba###\\13ß4ujs", r"\+'**'", r"###.#.####-ba"],
+            [r"abcabccba###" + 2 * self.bs, r"3ß4ujsabbc\+'**'ac###.#.####-ba"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = escaped_split(test_patterns[i],
+                                         self.multi_pattern_test_string)
             self.assertEqual(expected_results[i], return_value)
 
     # Test the basic unescaped_search_in_between() functionality.

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -57,6 +57,41 @@ class StringProcessingTest(unittest.TestCase):
                                            self.test_strings[i])
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the search_for() function.
+    def test_search_for(self):
+        # Match either "out1" or "out2".
+        search_pattern = "out1|out2"
+        # These are the expected results for the zero-group of the
+        # returned MatchObject's.
+        expected_results = [
+            [r"out1", r"out2"],
+            [r"out1", r"out2"],
+            [r"out1", r"out2"],
+            [r"out1", r"out2"],
+            [r"out1", r"out2"],
+            [r"out1", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = search_for(search_pattern, self.test_strings[i])
+
+            # Check each MatchObject. Need to iterate over the return_value
+            # since the return value is an iterator object pointing to the
+            # MatchObject's.
+            n = 0
+            for x in return_value:
+                self.assertEqual(expected_results[i][n], x.group(0))
+                n += 1
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)
 

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -197,7 +197,7 @@ class StringProcessingTest(unittest.TestCase):
             [2 * self.bs, 5 * self.bs, r"\\#", r"\\\'", self.bs, 4 * self.bs,
                 r"+ios"],
             [r"1", r"2", r"3", r"4", r"5", r"6"],
-            [r"1", r"2", r"3", r"4", r"5", r"6", r"7"],
+            [r"1", r"2", r"3", r"4", r"5", r"6", r"7"]
         ]
 
         for i in range(0, len(expected_results)):
@@ -350,7 +350,7 @@ class StringProcessingTest(unittest.TestCase):
             [],
             [2 * self.bs, r"\\\\\;\\#", r"\\\'", r"\;\\\\", r"+ios"],
             [r"1", r"2", r"3", r"4", r"5", r"6"],
-            [r"1", r"2", r"3", r"4", r"5", r"6", r"7"],
+            [r"1", r"2", r"3", r"4", r"5", r"6", r"7"]
         ]
 
         for i in range(0, len(expected_results)):

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -6,6 +6,11 @@ from coalib.parsing.StringProcessing import *
 
 class StringProcessingTest(unittest.TestCase):
     def setUp(self):
+        # The backslash character. Needed since there are limitations when
+        # using backslashes at the end of raw-strings in front of the
+        # terminating " or '.
+        self.bs = "\\"
+
         self.test_strings = [
             r"out1 'escaped-escape:        \\ ' out2",
             r"out1 'escaped-quote:         \' ' out2",
@@ -27,17 +32,22 @@ class StringProcessingTest(unittest.TestCase):
         self.multi_pattern_test_string = (r"abcabccba###\\13ß4ujsabbc\+'**'ac"
                                           r"###.#.####-ba")
 
+        # Multiple patterns for the multi-pattern tests.
+        self.multi_patterns = [r"abc",
+                               r"ab",
+                               r"ab|ac",
+                               2 * self.bs,
+                               r"#+",
+                               r"(a)|(b)|(#.)",
+                               r"(?:a(b)*c)+",
+                               r"1|\+"]
+
         # Test strings for the remove_empty_matches feature (alias auto-trim).
         self.auto_trim_test_strings = [
             r";;;;;;;;;;;;;;;;",
             r"\\;\\\\\;\\#;\\\';;\;\\\\;+ios;;",
             r"1;2;3;4;5;6;",
             r"1;2;3;4;5;6;7"]
-
-        # The backslash character. Needed since there are limitations when
-        # using backslashes at the end of raw-strings in front of the
-        # terminating " or '.
-        self.bs = "\\"
 
     # Test the basic unescaped_split() functionality.
     def test_unescaped_split(self):
@@ -160,13 +170,6 @@ class StringProcessingTest(unittest.TestCase):
 
     # Test the unescaped_split() function with different regex patterns.
     def test_unescaped_split_regex_pattern(self):
-        test_patterns = [r"abc",
-                         r"ab",
-                         r"ab|ac",
-                         2 * self.bs,
-                         r"#+",
-                         r"(a)|(b)|(#.)",
-                         r"(?:a(b)*c)+"]
         expected_results = [
             [r"", r"", r"cba###\\13ß4ujsabbc\+'**'ac###.#.####-ba"],
             [r"", r"c", r"ccba###\\13ß4ujs", r"bc\+'**'ac###.#.####-ba"],
@@ -175,12 +178,14 @@ class StringProcessingTest(unittest.TestCase):
             [r"abcabccba", r"\\13ß4ujsabbc\+'**'ac", r".", r".", r"-ba"],
             [r"", r"", r"c", r"", r"cc", r"", r"", r"", r"\13ß4ujs", r"", r"",
                 r"c\+'**'", r"c", r"", r"", r"", r"", r"-", r"", r""],
-            [r"", r"cba###\\13ß4ujs", r"\+'**'", r"###.#.####-ba"]
+            [r"", r"cba###\\13ß4ujs", r"\+'**'", r"###.#.####-ba"],
+            [r"abcabccba###" + 2 * self.bs, r"3ß4ujsabbc" + self.bs,
+                r"'**'ac###.#.####-ba"]
         ]
 
         for i in range(0, len(expected_results)):
             # Execute function under test.
-            return_value = unescaped_split(test_patterns[i],
+            return_value = unescaped_split(self.multi_patterns[i],
                                            self.multi_pattern_test_string)
             self.assertEqual(expected_results[i], return_value)
 
@@ -320,14 +325,6 @@ class StringProcessingTest(unittest.TestCase):
 
     # Test the escaped_split() function with different regex patterns.
     def test_escaped_split_regex_pattern(self):
-        test_patterns = [r"abc",
-                         r"ab",
-                         r"ab|ac",
-                         2 * self.bs,
-                         r"#+",
-                         r"(a)|(b)|(#.)",
-                         r"(?:a(b)*c)+",
-                         r"1|\+"]
         expected_results = [
             [r"", r"", r"cba###\\13ß4ujsabbc\+'**'ac###.#.####-ba"],
             [r"", r"c", r"ccba###\\13ß4ujs", r"bc\+'**'ac###.#.####-ba"],
@@ -342,7 +339,7 @@ class StringProcessingTest(unittest.TestCase):
 
         for i in range(0, len(expected_results)):
             # Execute function under test.
-            return_value = escaped_split(test_patterns[i],
+            return_value = escaped_split(self.multi_patterns[i],
                                          self.multi_pattern_test_string)
             self.assertEqual(expected_results[i], return_value)
 

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -476,6 +476,29 @@ class StringProcessingTest(unittest.TestCase):
                                                        max_match)
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the unescaped_search_in_between() function with different regex
+    # patterns.
+    def test_unescaped_search_in_between_regex_pattern(self):
+        expected_results = [
+            [r""],
+            [r"c"],
+            [r"c", r"bc\+'**'"],
+            [r""],
+            [r"\\13ß4ujsabbc\+'**'ac", r"."],
+            [r"", r"", r"", r"", r"", r"c\+'**'", r"", r"", r"-"],
+            [r"cba###\\13ß4ujs"],
+            [r"3ß4ujsabbc" + self.bs]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            # Use each pattern as begin and end sequence.
+            return_value = unescaped_search_in_between(
+                self.multi_patterns[i],
+                self.multi_patterns[i],
+                self.multi_pattern_test_string)
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the basic escaped_search_in_between() functionality.
     def test_escaped_search_in_between(self):
         begin_sequence = "'"

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -113,6 +113,34 @@ class StringProcessingTest(unittest.TestCase):
                                                        self.test_strings[i])
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the basic escaped_search_in_between() functionality.
+    def test_escaped_search_in_between(self):
+        begin_sequence = "'"
+        end_sequence = "'"
+        expected_results = [
+            [r"escaped-escape:        \\ "],
+            [r"escaped-quote:         \' "],
+            [r"escaped-anything:      \X "],
+            [r"two escaped escapes: \\\\ "],
+            [r"escaped-quote at end:   \'"],
+            [r"escaped-escape at end:  " + 2 * self.bs],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2", r"str3"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = escaped_search_in_between(begin_sequence,
+                                                     end_sequence,
+                                                     self.test_strings[i])
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the search_for() function.
     def test_search_for(self):
         # Match either "out1" or "out2".

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -659,6 +659,28 @@ class StringProcessingTest(unittest.TestCase):
                 self.multi_pattern_test_string)
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the escaped_search_in_between() function for its
+    # remove_empty_matches feature.
+    def test_escaped_search_in_between_auto_trim(self):
+        begin_sequence = ";"
+        end_sequence = ";"
+        expected_results = [
+            [],
+            [r"\\\\\;\\#", r"+ios"],
+            [r"2", r"4", r"6"],
+            [r"2", r"4", r"6"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = escaped_search_in_between(
+                begin_sequence,
+                end_sequence,
+                self.auto_trim_test_strings[i],
+                0,
+                True)
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the search_for() function.
     def test_search_for(self):
         # Match either "out1" or "out2".

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -27,6 +27,13 @@ class StringProcessingTest(unittest.TestCase):
         self.multi_pattern_test_string = (r"abcabccba###\\13ß4ujsabbc\+'**'ac"
                                           r"###.#.####-ba")
 
+        # Test strings for the remove_empty_matches feature (alias auto-trim).
+        self.auto_trim_test_strings = [
+            r";;;;;;;;;;;;;;;;",
+            r"\\;\\\\\;\\#;\\\';;\;\\\\;+ios;;",
+            r"1;2;3;4;5;6;",
+            r"1;2;3;4;5;6;7"]
+
         # The backslash character. Needed since there are limitations when
         # using backslashes at the end of raw-strings in front of the
         # terminating " or '.
@@ -175,6 +182,25 @@ class StringProcessingTest(unittest.TestCase):
             # Execute function under test.
             return_value = unescaped_split(test_patterns[i],
                                            self.multi_pattern_test_string)
+            self.assertEqual(expected_results[i], return_value)
+
+    # Test the unescaped_split() function for its remove_empty_matches feature.
+    def test_unescaped_split_auto_trim(self):
+        separator = ";"
+        expected_results = [
+            [],
+            [2 * self.bs, 5 * self.bs, r"\\#", r"\\\'", self.bs, 4 * self.bs,
+                r"+ios"],
+            [r"1", r"2", r"3", r"4", r"5", r"6"],
+            [r"1", r"2", r"3", r"4", r"5", r"6", r"7"],
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = unescaped_split(separator,
+                                           self.auto_trim_test_strings[i],
+                                           0,
+                                           True)
             self.assertEqual(expected_results[i], return_value)
 
     # Test the basic escaped_split() functionality.

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -392,6 +392,93 @@ class StringProcessingTest(unittest.TestCase):
                                                        self.test_strings[i])
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the unsecaped_search_in_between() while variating the max_match
+    # parameter.
+    def test_unescaped_search_in_between_max_match(self):
+        begin_sequence = "'"
+        end_sequence = "'"
+
+        # Testing max_match = 1
+        max_match = 1
+        expected_results = [
+            [r"escaped-escape:        \\ "],
+            [r"escaped-quote:         " + self.bs],
+            [r"escaped-anything:      \X "],
+            [r"two escaped escapes: \\\\ "],
+            [r"escaped-quote at end:   " + self.bs],
+            [r"escaped-escape at end:  " + 2 * self.bs],
+            [r"str1"],
+            [r"        "],
+            [r"      "],
+            [r"str1"],
+            [r"str1"],
+            [r"str1"],
+            [r"str1"],
+            [r"str1"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = unescaped_search_in_between(begin_sequence,
+                                                       end_sequence,
+                                                       self.test_strings[i],
+                                                       max_match)
+            self.assertEqual(expected_results[i], return_value)
+
+        # Testing max_match = 2
+        max_match = 2
+        expected_results = [
+            [r"escaped-escape:        \\ "],
+            [r"escaped-quote:         " + self.bs],
+            [r"escaped-anything:      \X "],
+            [r"two escaped escapes: \\\\ "],
+            [r"escaped-quote at end:   " + self.bs],
+            [r"escaped-escape at end:  " + 2 * self.bs],
+            [r"str1", r"str2"],
+            [r"        ", r" out2 "],
+            [r"      ", r" out2 "],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = unescaped_search_in_between(begin_sequence,
+                                                       end_sequence,
+                                                       self.test_strings[i],
+                                                       max_match)
+            self.assertEqual(expected_results[i], return_value)
+
+        # Testing max_match = 10
+        max_match = 10
+        expected_results = [
+            [r"escaped-escape:        \\ "],
+            [r"escaped-quote:         " + self.bs],
+            [r"escaped-anything:      \X "],
+            [r"two escaped escapes: \\\\ "],
+            [r"escaped-quote at end:   " + self.bs],
+            [r"escaped-escape at end:  " + 2 * self.bs],
+            [r"str1", r"str2"],
+            [r"        ", r" out2 "],
+            [r"      ", r" out2 "],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2", r"str3"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = unescaped_search_in_between(begin_sequence,
+                                                       end_sequence,
+                                                       self.test_strings[i],
+                                                       max_match)
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the basic escaped_search_in_between() functionality.
     def test_escaped_search_in_between(self):
         begin_sequence = "'"

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -614,6 +614,29 @@ class StringProcessingTest(unittest.TestCase):
                                                      max_match)
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the escaped_search_in_between() function with different regex
+    # patterns.
+    def test_escaped_search_in_between_regex_pattern(self):
+        expected_results = [
+            [r""],
+            [r"c"],
+            [r"c", r"bc\+'**'"],
+            [r"\13q4ujsabbc"],
+            [r"\\13q4ujsabbc\+'**'ac", r"."],
+            [r"", r"", r"", r"", r"", r"c\+'**'", r"", r"", r"-"],
+            [r"cba###\\13q4ujs"],
+            []
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            # Use each pattern as begin and end sequence.
+            return_value = escaped_search_in_between(
+                self.multi_patterns[i],
+                self.multi_patterns[i],
+                self.multi_pattern_test_string)
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the search_for() function.
     def test_search_for(self):
         # Match either "out1" or "out2".

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -57,6 +57,34 @@ class StringProcessingTest(unittest.TestCase):
                                            self.test_strings[i])
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the basic escaped_split() functionality.
+    def test_escaped_split(self):
+        separator_pattern = "'"
+        expected_results = [
+            [r"out1 ", r"escaped-escape:        \\ ", r" out2"],
+            [r"out1 ", r"escaped-quote:         \' ", r" out2"],
+            [r"out1 ", r"escaped-anything:      \X ", r" out2"],
+            [r"out1 ", r"two escaped escapes: \\\\ ", r" out2"],
+            [r"out1 ", r"escaped-quote at end:   \'", r" out2"],
+            [r"out1 ", r"escaped-escape at end:  " + 2 * self.bs, r" out2"],
+            [r"out1           ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \'        ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \\\'      ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \\        ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \\\\      ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1         " + 2 * self.bs, r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1       " + 4 * self.bs, r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1           ", r"str1", r"", r"str2", r"", r"str3", r" out2"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = escaped_split(separator_pattern,
+                                         self.test_strings[i])
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the search_for() function.
     def test_search_for(self):
         # Match either "out1" or "out2".

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -151,6 +151,32 @@ class StringProcessingTest(unittest.TestCase):
                                            max_split)
             self.assertEqual(expected_results[i], return_value)
 
+    # Test the unescaped_split() function with different regex patterns.
+    def test_unescaped_split_regex_pattern(self):
+        test_patterns = [r"abc",
+                         r"ab",
+                         r"ab|ac",
+                         2 * self.bs,
+                         r"#+",
+                         r"(a)|(b)|(#.)",
+                         r"(?:a(b)*c)+"]
+        expected_results = [
+            [r"", r"", r"cba###\\13ß4ujsabbc\+'**'ac###.#.####-ba"],
+            [r"", r"c", r"ccba###\\13ß4ujs", r"bc\+'**'ac###.#.####-ba"],
+            [r"", r"c", r"ccba###\\13ß4ujs", r"bc\+'**'", r"###.#.####-ba"],
+            [r"abcabccba###", r"", r"13ß4ujsabbc", r"+'**'ac###.#.####-ba"],
+            [r"abcabccba", r"\\13ß4ujsabbc\+'**'ac", r".", r".", r"-ba"],
+            [r"", r"", r"c", r"", r"cc", r"", r"", r"", r"\13ß4ujs", r"", r"",
+                r"c\+'**'", r"c", r"", r"", r"", r"", r"-", r"", r""],
+            [r"", r"cba###\\13ß4ujs", r"\+'**'", r"###.#.####-ba"]
+        ]
+
+        for i in range(0, len(expected_results)):
+            # Execute function under test.
+            return_value = unescaped_split(test_patterns[i],
+                                           self.multi_pattern_test_string)
+            self.assertEqual(expected_results[i], return_value)
+
     # Test the basic escaped_split() functionality.
     def test_escaped_split(self):
         separator_pattern = "'"


### PR DESCRIPTION
The long awaited regex functions that automatically escape (or not escape) characters.

Fixes #160.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/coala-analyzer/coala/pull/357%23issuecomment-77102286%22%2C%20%22https%3A//github.com/coala-analyzer/coala/pull/357%23issuecomment-77102526%22%2C%20%22https%3A//github.com/coala-analyzer/coala/commit/7738a038691d814e6ccd85251c2fbcc76835db14%23commitcomment-10022785%22%2C%20%22https%3A//github.com/coala-analyzer/coala/commit/01db6ae6d107e995350c51cd3c49c39a41cb9ca4%23commitcomment-10022802%22%2C%20%22https%3A//github.com/coala-analyzer/coala/commit/01db6ae6d107e995350c51cd3c49c39a41cb9ca4%23commitcomment-10022822%22%2C%20%22https%3A//github.com/coala-analyzer/coala/commit/01db6ae6d107e995350c51cd3c49c39a41cb9ca4%23commitcomment-10022834%22%2C%20%22https%3A//github.com/coala-analyzer/coala/commit/01db6ae6d107e995350c51cd3c49c39a41cb9ca4%23commitcomment-10034759%22%2C%20%22https%3A//github.com/coala-analyzer/coala/pull/357%23issuecomment-77206703%22%2C%20%22https%3A//github.com/coala-analyzer/coala/pull/357%23issuecomment-77207041%22%2C%20%22https%3A//github.com/coala-analyzer/coala/pull/357%23issuecomment-77207326%22%2C%20%22https%3A//github.com/coala-analyzer/coala/pull/357%23issuecomment-77208504%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/coala-analyzer/coala/pull/357%23issuecomment-77102286%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22you%20sure%2C%20you%20want%20to%20submit%20that%20for%20review%3F%20You%20e.g.%20have%20two%20commits%20with%20the%20same%20message%20in%20it.%5Cr%5Cn%5Cr%5CnAlso%20as%20I%20mentioned%20on%20gitter%2C%20you%20want%20to%20add%20tests%20in%20the%20same%20commit%20where%20you%20add%20functionailty.%22%2C%20%22created_at%22%3A%20%222015-03-04T06%3A07%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5716520%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sils1297%22%7D%7D%2C%20%7B%22body%22%3A%20%22having%20small%20and%20concise%20commits%20is%20meant%20for%20maximum%20code%20quality%2C%20not%20for%20mirroring%20how%20the%20code%20was%20created.%20%28There%20are%20other%20workflows%20that%20optimize%20for%20that.%29%20So%20you%20don%27t%20want%20to%20have%20%60fix%20this%20and%20that%60%20commits%20in%20it%20when%20you%27re%20creating%20new%20stuff.%20You%20can%20mention%20potential%20bugs%20but%20the%20best%20you%20can%20do%20to%20highlight%20them%20is%20adding%20a%20test%20for%20exactly%20the%20cases%20where%20you%20failed%20in%20the%20first%20place%20because%20that%27s%20where%20others%20may%20fail%20too%20when%20they%27re%20trying%20to%20rewrite%20something.%5Cr%5Cn%5Cr%5CnAs%20for%20me%20I%20usually%20don%27t%20want%20to%20care%20on%20what%20branch%20or%20in%20which%20order%20a%20code%20was%20developed.%20I%20usually%20want%20to%20easily%20be%20able%20to%20say%20that%20there%20are%20no%20bugs%20in%20it.%22%2C%20%22created_at%22%3A%20%222015-03-04T06%3A11%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5716520%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sils1297%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thought%20so%2C%20but%20I%20tried%20to%20hand%20it%20to%20you%20as%20finished%20%3Apackage%3A%20%5Cr%5CnAs%20you%20see%20there%20was%20quite%20much%20to%20do.%5Cr%5CnSo%20I%20would%20copy%20the%20branch%20and%20make%20a%20v2%20of%20it.%20How%20did%20you%20do%20that%20with%20your%20pull%20requests%3F%22%2C%20%22created_at%22%3A%20%222015-03-04T17%3A42%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6023916%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Makman2%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20just%20branched%20off%20a%20v2%20and%20edited%20commit%20and%20pushed%20up.%22%2C%20%22created_at%22%3A%20%222015-03-04T17%3A43%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5716520%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sils1297%22%7D%7D%2C%20%7B%22body%22%3A%20%22hey%2C%20this%20code%20review%20tool%20even%20gives%20you%20a%20task%20list%20out%20of%20my%20comments%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-03-04T17%3A44%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5716520%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sils1297%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20it%20doesn%27t%20look%20so%20good%5E%5E%22%2C%20%22created_at%22%3A%20%222015-03-04T17%3A50%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6023916%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Makman2%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Commit%2001db6ae6d107e995350c51cd3c49c39a41cb9ca4%20coalib/parsing/StringProcessing.py%2012%2047%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/coala-analyzer/coala/commit/01db6ae6d107e995350c51cd3c49c39a41cb9ca4%23commitcomment-10022802%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20very%20obvious%20that%20it%27s%20optional%2C%20isn%27t%20it%3F%22%2C%20%22created_at%22%3A%20%222015-03-04T06%3A02%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5716520%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sils1297%22%7D%7D%2C%20%7B%22body%22%3A%20%22you%20don%27t%20specify%20return%20value%20by%20the%20way%20and%20thats%20most%20importtant%20here%20because%20you%20could%20do%20that%20in%20various%20ways.%22%2C%20%22created_at%22%3A%20%222015-03-04T06%3A05%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5716520%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sils1297%22%7D%7D%2C%20%7B%22body%22%3A%20%22damn%20completely%20forgot.%20That%27s%20the%20thing%20if%20you%20don%27t%20have%20return%20types%20in%20the%20declaration...%22%2C%20%22created_at%22%3A%20%222015-03-04T17%3A39%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6023916%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Makman2%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20coalib/parsing/StringProcessing.py%3AL47%20%2801db6ae%29%22%7D%2C%20%22Commit%2001db6ae6d107e995350c51cd3c49c39a41cb9ca4%20coalib/parsing/StringProcessing.py%2019%2054%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/coala-analyzer/coala/commit/01db6ae6d107e995350c51cd3c49c39a41cb9ca4%23commitcomment-10022822%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60rxc%60%20is%20a%20bad%20name.%20In%20this%20line%20I%20know%20what%20it%20means%20but%20if%20I%27m%20scanning%20the%20function%20fastly%20to%20grasp%20its%20functionality%20or%20so%20I%20would%20need%20to%20look%20up%20the%20declaration%20to%20see%20what%20it%20means.%20IMO%20you%20could%20be%20a%20bit%20more%20verbose.%20rxc%20is%20also%20not%20a%20common%20abbreviation.%22%2C%20%22created_at%22%3A%20%222015-03-04T06%3A04%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5716520%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sils1297%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20coalib/parsing/StringProcessing.py%3AL54%20%2801db6ae%29%22%7D%2C%20%22Commit%207738a038691d814e6ccd85251c2fbcc76835db14%20coalib/parsing/StringProcessing.py%208%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/coala-analyzer/coala/commit/7738a038691d814e6ccd85251c2fbcc76835db14%23commitcomment-10022785%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27d%20expect%20a%20newline%20after%20short%20description.%20%28Our%20documentation%20parser%20does%20expect%20that%20too%2C%20markdown%20like.%29%22%2C%20%22created_at%22%3A%20%222015-03-04T06%3A01%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5716520%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sils1297%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20coalib/parsing/StringProcessing.py%3AL8%20%287738a03%29%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Commit 7738a038691d814e6ccd85251c2fbcc76835db14 coalib/parsing/StringProcessing.py 8 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/coala-analyzer/coala/commit/7738a038691d814e6ccd85251c2fbcc76835db14#commitcomment-10022785'>File: coalib/parsing/StringProcessing.py:L8 (7738a03)</a></b>
- <a href='https://github.com/sils1297'><img border=0 src='https://avatars.githubusercontent.com/u/5716520?v=3' height=16 width=16'></a> I'd expect a newline after short description. (Our documentation parser does expect that too, markdown like.)
- [ ] <a href='#crh-comment-Commit 01db6ae6d107e995350c51cd3c49c39a41cb9ca4 coalib/parsing/StringProcessing.py 12 47'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/coala-analyzer/coala/commit/01db6ae6d107e995350c51cd3c49c39a41cb9ca4#commitcomment-10022802'>File: coalib/parsing/StringProcessing.py:L47 (01db6ae)</a></b>
- <a href='https://github.com/sils1297'><img border=0 src='https://avatars.githubusercontent.com/u/5716520?v=3' height=16 width=16'></a> It's very obvious that it's optional, isn't it?
- <a href='https://github.com/sils1297'><img border=0 src='https://avatars.githubusercontent.com/u/5716520?v=3' height=16 width=16'></a> you don't specify return value by the way and thats most importtant here because you could do that in various ways.
- <a href='https://github.com/Makman2'><img border=0 src='https://avatars.githubusercontent.com/u/6023916?v=3' height=16 width=16'></a> damn completely forgot. That's the thing if you don't have return types in the declaration...
- [ ] <a href='#crh-comment-Commit 01db6ae6d107e995350c51cd3c49c39a41cb9ca4 coalib/parsing/StringProcessing.py 19 54'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/coala-analyzer/coala/commit/01db6ae6d107e995350c51cd3c49c39a41cb9ca4#commitcomment-10022822'>File: coalib/parsing/StringProcessing.py:L54 (01db6ae)</a></b>
- <a href='https://github.com/sils1297'><img border=0 src='https://avatars.githubusercontent.com/u/5716520?v=3' height=16 width=16'></a> `rxc` is a bad name. In this line I know what it means but if I'm scanning the function fastly to grasp its functionality or so I would need to look up the declaration to see what it means. IMO you could be a bit more verbose. rxc is also not a common abbreviation.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/coala-analyzer/coala/pull/357#issuecomment-77102286'>General Comment</a></b>
- <a href='https://github.com/sils1297'><img border=0 src='https://avatars.githubusercontent.com/u/5716520?v=3' height=16 width=16'></a> you sure, you want to submit that for review? You e.g. have two commits with the same message in it.
Also as I mentioned on gitter, you want to add tests in the same commit where you add functionailty.
- <a href='https://github.com/sils1297'><img border=0 src='https://avatars.githubusercontent.com/u/5716520?v=3' height=16 width=16'></a> having small and concise commits is meant for maximum code quality, not for mirroring how the code was created. (There are other workflows that optimize for that.) So you don't want to have `fix this and that` commits in it when you're creating new stuff. You can mention potential bugs but the best you can do to highlight them is adding a test for exactly the cases where you failed in the first place because that's where others may fail too when they're trying to rewrite something.
As for me I usually don't want to care on what branch or in which order a code was developed. I usually want to easily be able to say that there are no bugs in it.
- <a href='https://github.com/Makman2'><img border=0 src='https://avatars.githubusercontent.com/u/6023916?v=3' height=16 width=16'></a> Thought so, but I tried to hand it to you as finished :package:
As you see there was quite much to do.
So I would copy the branch and make a v2 of it. How did you do that with your pull requests?
- <a href='https://github.com/sils1297'><img border=0 src='https://avatars.githubusercontent.com/u/5716520?v=3' height=16 width=16'></a> I just branched off a v2 and edited commit and pushed up.
- <a href='https://github.com/sils1297'><img border=0 src='https://avatars.githubusercontent.com/u/5716520?v=3' height=16 width=16'></a> hey, this code review tool even gives you a task list out of my comments :)
- <a href='https://github.com/Makman2'><img border=0 src='https://avatars.githubusercontent.com/u/6023916?v=3' height=16 width=16'></a> But it doesn't look so good^^


<a href='https://www.codereviewhub.com/coala-analyzer/coala/pull/357?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/coala-analyzer/coala/pull/357?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/coala-analyzer/coala/pull/357'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>