### PR TITLE
Make ResultAction settings settable from config files

### DIFF
--- a/coalib/output/ConsoleInteractor.py
+++ b/coalib/output/ConsoleInteractor.py
@@ -98,19 +98,21 @@ class ConsoleInteractor(Interactor, ConsolePrinter):
 
     def _get_action_info(self, action):
         # Otherwise we have a recursive import
-        from coalib.settings.Section import Section
         from coalib.settings.Setting import Setting
 
         params = action.non_optional_params
-        section = Section("")
+
+        if self.current_section is None:
+            raise ValueError("current_section has to be intializied.")
 
         for param_name in params:
-            question = self._format_line(
-                _("Please enter a value for the parameter '{}' ({}): ")
-                .format(param_name, params[param_name][0]))
-            section.append(Setting(param_name, input(question)))
+            if param_name not in self.current_section:
+                question = self._format_line(
+                    _("Please enter a value for the parameter '{}' ({}): ")
+                    .format(param_name, params[param_name][0]))
+                self.current_section.append(Setting(param_name, input(question)))
 
-        return action.name, section
+        return action.name, self.current_section
 
     def _print_segregation(self):
         self.print(self._format_line(line="", real_nr="...", sign="|", mod_nr="..."))

--- a/coalib/output/ConsoleInteractor.py
+++ b/coalib/output/ConsoleInteractor.py
@@ -167,8 +167,8 @@ class ConsoleInteractor(Interactor, ConsolePrinter):
 
             self.print_result(result, file_dict)
 
-    def begin_section(self, name):
-        self.print(_("Executing section {name}...").format(name=name))
+    def _print_section_beginning(self, section):
+        self.print(_("Executing section {name}...").format(name=section.name))
 
     def did_nothing(self):
         self.print(_("No existent section was targeted or enabled. Nothing "

--- a/coalib/output/Interactor.py
+++ b/coalib/output/Interactor.py
@@ -121,12 +121,21 @@ class Interactor(SectionCreatable):
         return FunctionMetadata.from_function(cls.__init__,
                                               ["self", "log_printer"])
 
-    def begin_section(self, name):
+    def begin_section(self, section):
         """
         Will be called before the results for a section come in (via
         print_results).
 
-        :param name: The name of the section that will get executed now.
+        :param section: The section that will get executed now.
+        """
+        self._print_section_beginning(section)
+
+    def _print_section_beginning(self, section):
+        """
+        Will be called after initialization current_section in
+        begin_section()
+
+        :param section: The section that will get executed now.
         """
         raise NotImplementedError
 

--- a/coalib/output/Interactor.py
+++ b/coalib/output/Interactor.py
@@ -12,6 +12,7 @@ class Interactor(SectionCreatable):
         SectionCreatable.__init__(self)
         self.log_printer = log_printer
         self.file_diff_dict = {}
+        self.current_section = None
 
     def _print_result(self, result):
         """
@@ -128,6 +129,7 @@ class Interactor(SectionCreatable):
 
         :param section: The section that will get executed now.
         """
+        self.current_section = section
         self._print_section_beginning(section)
 
     def _print_section_beginning(self, section):

--- a/coalib/output/NullInteractor.py
+++ b/coalib/output/NullInteractor.py
@@ -11,7 +11,7 @@ class NullInteractor(Interactor):
     def did_nothing(self):
         pass
 
-    def begin_section(self, name):
+    def _print_section_beginning(self, section):
         pass
 
     def acquire_settings(self, settings):

--- a/coalib/processes/SectionExecutor.py
+++ b/coalib/processes/SectionExecutor.py
@@ -72,7 +72,7 @@ class SectionExecutor:
 
         :return: True if results were yielded, False otherwise.
         """
-        self.section.interactor.begin_section(self.section.name)
+        self.section.interactor.begin_section(self.section)
 
         running_processes = get_cpu_count()
         processes, arg_dict = self._instantiate_processes(running_processes)

--- a/coalib/tests/output/ConsoleInteractorTest.py
+++ b/coalib/tests/output/ConsoleInteractorTest.py
@@ -118,7 +118,7 @@ class ConsoleInteractorTestCase(unittest.TestCase):
         q = queue.Queue()
         # 0:-1 to strip of the trailing newline character
         self.uut._print = lambda string: q.put(string[0:-1])
-        self.uut.begin_section("name")
+        self.uut.begin_section(Section("name"))
         self.assertEqual(q.get(timeout=0), _("Executing section "
                                              "{name}...").format(name="name"))
 


### PR DESCRIPTION
Make begin_section() save the section that we currently use proccess
it, and when user inter parmeter to a certain action, ConsoleInteractor
save it in current_section settings

see: #330