### PR TITLE
Misc message fixes

### DIFF
--- a/doc/getting_involved/MAC_hints.md
+++ b/doc/getting_involved/MAC_hints.md
@@ -1,0 +1,49 @@
+## Coverage Installation Hints for OSX Users:
+
+##### 1. Make sure you have installed Xcode and Homebrew.
+
+##### 2. Install Python3.
+
+
+    brew search python  # This should display python3
+    brew install python3
+    python3 --version   # To check the installed version
+
+##### 3. Create Virtual environments with pyvenv
+
+    # Create Virtual Env named myenv
+    pyvenv myenv
+
+    # This will create a folder named myenv in the
+    # current directory. To activate this environment just type
+    source myenv/bin/activate
+
+    # You can start Python3 by typing:
+    python
+
+##### 4. Virtualenvwrapper with Python 3:
+
+    # Installation
+    pip install virtualenv
+    pip install virtualenvwrapper
+
+    # Folder to contain Virtual Environments
+    mkdir ~/.virtualenvs
+
+    # Add the following in ~/.bash_profile
+    export WORKON_HOME=~/.virtualenvs
+    source /usr/local/bin/virtualenvwrapper.sh
+
+    # Activate Changes
+    source ~/.bash_profile
+
+    # Get Python3 path (python3_pth)
+    where python3
+
+    # Create a new virtual environment with Python3
+    mkvirtualenv --python=python3_path myenv
+
+##### Finally!
+
+    # Install python-coverage3 by
+    easy_install coverage


### PR DESCRIPTION
Executing "run_tests.py" without installing gettext, prompts the user with the following message:
![screen shot 2015-03-07 at 1 34 05 pm](https://cloud.githubusercontent.com/assets/2330579/6540679/b59f6a78-c4d1-11e4-9990-8bc69a6dc3b3.png)
The message is not clear enough to state that, msgfmt requires "gettext" to be installed in the correct path so as to recover from the error.
The error message needs to be fixed for the same.