### PR TITLE
Makman2/escaping3

### DIFF
--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -39,3 +39,59 @@ def limit(iterator, count):
             if i == count:
                 break
 
+
+def split(pattern,
+          string,
+          max_split = 0,
+          remove_empty_matches = False):
+    """
+    Splits the given string by the specified pattern. The return character (\n)
+    is not a natural split pattern (if you don't specify it yourself).
+    This function ignores escape sequences.
+
+    :param pattern:              A regex pattern that defines where to split.
+    :param string:               The string to split by the defined pattern.
+    :param max_split:            Defines the maximum number of splits. If 0 or
+                                 less is provided, the number of splits is not
+                                 limited.
+    :param remove_empty_matches: Defines whether empty entries should
+                                 be removed from the result.
+    :return:                     An iterator returning the split up strings.
+    """
+    # re.split() is not usable for this function. It has a bug when using too
+    # many capturing groups "()".
+
+    # Regex explanation:
+    # 1. (.*?)              Match any char unlimited times, as few times as
+    #                       possible. Save the match in the first capturing
+    #                       group (match.group(1)).
+    # 2. (?:pattern)        A non-capturing group that matches the
+    #                       split-pattern. Because the first group is lazy
+    #                       (matches as few times as possible) the next
+    #                       occurring split-sequence is matched.
+    regex = r"(.*?)(?:" + pattern + r")"
+
+    i = 0
+    item = None
+    for item in re.finditer(regex, string, re.DOTALL):
+        if not remove_empty_matches or len(item.group(1)) != 0:
+            # Return the first matching group. The pattern from parameter can't
+            # change the group order.
+            yield item.group(1)
+
+            i += 1
+            if i == max_split:
+                # Only if max_split > 0 this code is reachable, so
+                # max_split == 0 performs infinite splits.
+                break
+
+    if item is None:
+        last_pos = 0
+    else:
+        last_pos = item.end()
+
+    # Append the rest of the string, since it's not in the result list (only
+    # matches are captured that have a leading separator).
+    if not remove_empty_matches or len(string) > last_pos:
+        yield string[last_pos : ]
+

--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -40,6 +40,28 @@ def limit(iterator, count):
                 break
 
 
+def trim_empty_matches(iterator, groups = [0]):
+    """
+    A filter that removes empty match strings. It can only operate on iterators
+    whose elements are of type MatchObject.
+
+    :param iterator: The iterator to be filtered.
+    :param groups:   An iteratable defining the groups to check for blankness.
+                     Only results are not yielded if all groups of the match
+                     are blank.
+                     You can not only pass numbers but also strings, if your
+                     MatchObject contains named groups.
+    """
+    for elem in iterator:
+        yield_result = False
+        for group in groups:
+            if len(elem.group(group)) != 0:
+                yield_result = True
+
+        if yield_result:
+            yield elem
+
+
 def split(pattern,
           string,
           max_split = 0,
@@ -167,4 +189,54 @@ def unescaped_split(pattern,
     # matches are captured that have a leading separator).
     if not remove_empty_matches or len(string) > last_pos:
         yield string[last_pos : ]
+
+
+def search_in_between(begin,
+                      end,
+                      string,
+                      max_matches = 0,
+                      remove_empty_matches = False):
+    """
+    Searches for a string enclosed between a specified begin- and end-sequence.
+    Also enclosed \n are put into the result. Doesn't handle escape sequences.
+    This function is a generator.
+
+    :param begin:                A regex pattern that defines where to start
+                                 matching.
+    :param end:                  A regex pattern that defines where to end
+                                 matching.
+    :param string:               The string where to search in.
+    :param max_matches           Defines the maximum number of matches. If 0 or
+                                 less is provided, the number of splits is not
+                                 limited.
+    :param remove_empty_matches: Defines whether empty entries should
+                                 be removed from the result.
+    :return:                     An iterator returning the matched strings.
+    """
+
+    # Compilation of the begin sequence is needed to get the number of
+    # capturing groups in it.
+    compiled_begin_pattern = re.compile(begin)
+
+    # Regex explanation:
+    # 1. (?:begin) A non-capturing group that matches the begin sequence.
+    # 2. (.*?)     Match any char unlimited times, as few times as possible.
+    #              Save the match in the first capturing group
+    #              (match.group(1)).
+    # 3. (?:end)   A non-capturing group that matches the end sequence.
+    #              Because the previous group is lazy (matches as few times as
+    #              possible) the next occurring end-sequence is matched.
+    regex = r"(?:" + begin + r")(.*?)(?:" + end + r")"
+
+    matches = re.finditer(regex, string, re.DOTALL)
+
+    if remove_empty_matches:
+        matches = trim_empty_matches(
+            matches,
+            [compiled_begin_pattern.groups + 1])
+
+    matches = limit(matches, max_matches)
+
+    for elem in matches:
+        yield elem.group(compiled_begin_pattern.groups + 1)
 

--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -95,3 +95,76 @@ def split(pattern,
     if not remove_empty_matches or len(string) > last_pos:
         yield string[last_pos : ]
 
+
+def unescaped_split(pattern,
+                    string,
+                    max_split = 0,
+                    remove_empty_matches = False):
+    """
+    Splits the given string by the specified pattern. The return character (\n)
+    is not a natural split pattern (if you don't specify it yourself).
+    This function handles escaped split-patterns (and so splits only patterns
+    that are unescaped).
+    CAUTION: Using the escaped character '\' in the pattern the function can
+             return strange results. The backslash can interfere with the
+             escaping regex-sequence used internally to split.
+
+    :param pattern:              A regex pattern that defines where to split.
+    :param string:               The string to split by the defined pattern.
+    :param max_split:            Defines the maximum number of splits. If 0 or
+                                 less is provided, the number of splits is not
+                                 limited.
+    :param remove_empty_matches: Defines whether empty entries should
+                                 be removed from the result.
+    :return:                     An iterator returning the split up strings.
+    """
+    # Need to use re.search() since using splitting directly is not possible.
+    # We need to match the separator only if the number of escapes is even.
+    # The solution is to use look-behind-assertions, but these don't support a
+    # variable number of letters (means quantifiers are not usable there). So
+    # if we try to match the escape sequences too, they would be replaced,
+    # because they are consumed then by the regex. That's not wanted.
+
+    # Regex explanation:
+    # 1. (.*?)              Match any char unlimited times, as few times as
+    #                       possible. Save the match in the first capturing
+    #                       group (match.group(1)).
+    # 2. (?<!\\)((?:\\\\)*) Unescaping sequence. Only matches backslashes if
+    #                       their count is even.
+    # 3. (?:pattern)        A non-capturing group that matches the
+    #                       split-pattern. Because the first group is lazy
+    #                       (matches as few times as possible) the next
+    #                       occurring split-sequence is matched.
+    regex = r"(.*?)(?<!\\)((?:\\\\)*)(?:" + pattern + r")"
+
+    i = 0
+    item = None
+    for item in re.finditer(regex, string, re.DOTALL):
+        concat_string = item.group(1)
+
+        if item.group(2) is not None:
+            # Escaped escapes were consumed from the second group, append them
+            # too.
+            concat_string += item.group(2)
+
+        if not remove_empty_matches or len(concat_string) != 0:
+            # Return the first matching group. The pattern from parameter can't
+            # change the group order.
+            yield concat_string
+
+            i += 1
+            if i == max_split:
+                # Only if max_split > 0 this code is reachable, so
+                # max_split == 0 performs infinite splits.
+                break
+
+    if item is None:
+        last_pos = 0
+    else:
+        last_pos = item.end()
+
+    # Append the rest of the string, since it's not in the result list (only
+    # matches are captured that have a leading separator).
+    if not remove_empty_matches or len(string) > last_pos:
+        yield string[last_pos : ]
+

--- a/coalib/parsing/StringProcessing.py
+++ b/coalib/parsing/StringProcessing.py
@@ -1,0 +1,41 @@
+import re
+
+
+def search_for(pattern, string, flags = 0, max_match = 0):
+    """
+    Searches for a given pattern in a string.
+
+    :param pattern:   A regex pattern that defines what to match.
+    :param string:    The string to search in.
+    :param flags:     Additional flags to pass to the regex processor.
+    :param max_match: Defines the maximum number of matches to perform. If 0 or
+                      less is provided, the number of splits is not limited.
+    :return:          An iterator returning MatchObject's.
+    """
+    for elem in limit(re.finditer(pattern, string, flags), max_match):
+        yield elem
+
+
+def limit(iterator, count):
+    """
+    A filter that removes all elements behind the set limit.
+
+    :param iterator: The iterator to be filtered.
+    :param count:    The iterator limit. All elements at positions bigger than
+                     this limit are trimmed off. Exclusion: 0 or numbers below
+                     does not limit at all, means the passed iterator is
+                     completely yielded.
+    """
+    if count <= 0:
+        # Use a separate if branch to speed up a bit (since we don't need a
+        # counter here).
+        for elem in iterator:
+            yield elem
+    else:
+        i = 0
+        for elem in iterator:
+            yield elem
+            i += 1
+            if i == count:
+                break
+

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -5,6 +5,7 @@ import unittest
 from coalib.parsing.StringProcessing import search_for
 from coalib.parsing.StringProcessing import split
 from coalib.parsing.StringProcessing import unescaped_split
+from coalib.parsing.StringProcessing import search_in_between
 
 
 class StringProcessingTest(unittest.TestCase):
@@ -65,6 +66,7 @@ class StringProcessingTest(unittest.TestCase):
         self.setUp_search_for()
         self.setUp_split()
         self.setUp_unescaped_split()
+        self.setUp_search_in_between()
 
     def setUp_search_for(self):
         # Match either "out1" or "out2".
@@ -213,6 +215,55 @@ class StringProcessingTest(unittest.TestCase):
             [r"\;"],
             [2 * self.bs],
             [r"abc", r"a", r"asc"]]
+
+    def setUp_search_in_between(self):
+        self.test_search_in_between_pattern = "'"
+        self.test_search_in_between_expected_results = [
+            [r"escaped-escape:        \\ "],
+            [r"escaped-quote:         " + self.bs],
+            [r"escaped-anything:      \X "],
+            [r"two escaped escapes: \\\\ "],
+            [r"escaped-quote at end:   " + self.bs],
+            [r"escaped-escape at end:  " + 2 * self.bs],
+            [r"str1", r"str2"],
+            [r"        ", r" out2 "],
+            [r"      ", r" out2 "],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2"],
+            [r"str1", r"str2", r"str3"],
+            [],
+            [],
+            [],
+            []]
+
+        self.test_search_in_between_max_match_pattern = (
+            self.test_search_in_between_pattern)
+        self.test_search_in_between_max_match_expected_master_results = (
+            self.test_search_in_between_expected_results)
+
+        self.test_search_in_between_regex_pattern_expected_results = [
+            [r""],
+            [r"c"],
+            [r"c", r"bc\+'**'"],
+            [r""],
+            [r"\\13q4ujsabbc\+'**'ac", r"."],
+            [r"", r"", r"", r"", r"", r"c\+'**'", r"", r"", r"-"],
+            [r"cba###\\13q4ujs"],
+            [r"3q4ujsabbc" + self.bs]]
+
+        self.test_search_in_between_auto_trim_pattern = ";"
+        self.test_search_in_between_auto_trim_expected_results = [
+            [],
+            [5 * self.bs, r"\\\'", self.bs, r"+ios"],
+            [r"2", r"4", r"6"],
+            [r"2", r"4", r"6"],
+            [],
+            [],
+            [],
+            [],
+            [r"a"]]
 
     def assertSearchForResultEqual(self,
                                    pattern,
@@ -432,6 +483,73 @@ class StringProcessingTest(unittest.TestCase):
                                            self.auto_trim_test_strings[i],
                                            0,
                                            True)
+            self.assertIteratorElementsEqual(iter(expected_results[i]),
+                                             return_value)
+
+    # Test the basic search_in_between() functionality.
+    def test_search_in_between(self):
+        sequence = self.test_search_in_between_pattern
+        expected_results = self.test_search_in_between_expected_results
+
+        self.assertEqual(len(expected_results), len(self.test_strings))
+        for i in range(0, len(expected_results)):
+            return_value = search_in_between(sequence,
+                                             sequence,
+                                             self.test_strings[i])
+            self.assertIteratorElementsEqual(iter(expected_results[i]),
+                                             return_value)
+
+    # Test the search_in_between() while varying the max_match
+    # parameter.
+    def test_search_in_between_max_match(self):
+        sequence = self.test_search_in_between_max_match_pattern
+        expected_master_results = (
+            self.test_search_in_between_max_match_expected_master_results)
+
+        for max_match in [1, 2, 3, 4, 5, 100]:
+            expected_results = [
+                expected_master_results[j][0 : max_match]
+                for j in range(len(expected_master_results))]
+
+            self.assertEqual(len(expected_results), len(self.test_strings))
+            for x in range(0, len(expected_results)):
+                return_value = search_in_between(sequence,
+                                                 sequence,
+                                                 self.test_strings[x],
+                                                 max_match)
+                self.assertIteratorElementsEqual(iter(expected_results[x]),
+                                                 return_value)
+
+    # Test the search_in_between() function with different regex
+    # patterns.
+    def test_search_in_between_regex_pattern(self):
+        expected_results = (
+            self.test_search_in_between_regex_pattern_expected_results)
+
+        self.assertEqual(len(expected_results), len(self.multi_patterns))
+        for i in range(0, len(expected_results)):
+            # Use each pattern as begin and end sequence.
+            return_value = search_in_between(self.multi_patterns[i],
+                                             self.multi_patterns[i],
+                                             self.multi_pattern_test_string)
+            self.assertIteratorElementsEqual(iter(expected_results[i]),
+                                             return_value)
+
+    # Test the search_in_between() function for its
+    # remove_empty_matches feature.
+    def test_search_in_between_auto_trim(self):
+        sequence = self.test_search_in_between_auto_trim_pattern
+        expected_results = (
+            self.test_search_in_between_auto_trim_expected_results)
+
+        self.assertEqual(len(expected_results),
+                         len(self.auto_trim_test_strings))
+        for i in range(0, len(expected_results)):
+            return_value = search_in_between(sequence,
+                                             sequence,
+                                             self.auto_trim_test_strings[i],
+                                             0,
+                                             True)
             self.assertIteratorElementsEqual(iter(expected_results[i]),
                                              return_value)
 

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -1,0 +1,156 @@
+import sys
+sys.path.insert(0, ".")
+import unittest
+
+from coalib.parsing.StringProcessing import search_for
+
+
+class StringProcessingTest(unittest.TestCase):
+    def setUp(self):
+        # The backslash character. Needed since there are limitations when
+        # using backslashes at the end of raw-strings in front of the
+        # terminating " or '.
+        self.bs = "\\"
+
+        self.test_strings = [
+            r"out1 'escaped-escape:        \\ ' out2",
+            r"out1 'escaped-quote:         \' ' out2",
+            r"out1 'escaped-anything:      \X ' out2",
+            r"out1 'two escaped escapes: \\\\ ' out2",
+            r"out1 'escaped-quote at end:   \'' out2",
+            r"out1 'escaped-escape at end:  \\' out2",
+            r"out1           'str1' out2 'str2' out2",
+            r"out1 \'        'str1' out2 'str2' out2",
+            r"out1 \\\'      'str1' out2 'str2' out2",
+            r"out1 \\        'str1' out2 'str2' out2",
+            r"out1 \\\\      'str1' out2 'str2' out2",
+            r"out1         \\'str1' out2 'str2' out2",
+            r"out1       \\\\'str1' out2 'str2' out2",
+            r"out1           'str1''str2''str3' out2",
+            r"",
+            r"out1 out2 out3",
+            self.bs,
+            2 * self.bs]
+
+        # Set up test dependent variables.
+        self.setUp_search_for()
+
+    def setUp_search_for(self):
+        # Match either "out1" or "out2".
+        self.test_search_for_pattern = "out1|out2"
+        # These are the expected results for the zero-group of the
+        # returned MatchObject's.
+        self.test_search_for_expected_results = [
+            [r"out1", r"out2"],
+            [r"out1", r"out2"],
+            [r"out1", r"out2"],
+            [r"out1", r"out2"],
+            [r"out1", r"out2"],
+            [r"out1", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2", r"out2"],
+            [r"out1", r"out2"],
+            [],
+            [r"out1", r"out2"],
+            [],
+            []]
+
+        self.test_search_for_simple_pattern_pattern = "'"
+        self.test_search_for_simple_pattern_expected_results = [
+            i * [r"'"] for i in
+                [2, 3, 2, 2, 3, 2, 4, 5, 5, 4, 4, 4, 4, 6, 0, 0, 0, 0]]
+
+        self.test_search_for_empty_pattern_pattern = ""
+        self.test_search_for_empty_pattern_expected_results = [
+            (len(elem) + 1) * [r""] for elem in self.test_strings]
+
+        self.test_search_for_max_match_pattern = self.test_search_for_pattern
+        self.test_search_for_max_match_expected_master_result = (
+            self.test_search_for_expected_results)
+
+    def assertSearchForResultEqual(self,
+                                   pattern,
+                                   test_strings,
+                                   expected_strings,
+                                   flags = 0,
+                                   max_match = 0):
+        """
+        Checks whether the given test_strings do equal the expected_strings
+        after feeding search_for() with them.
+
+        :param pattern:          The pattern to pass to search_for().
+        :param test_strings:     The test string to pass to search_for().
+        :param expected_strings: The expected results to make the asserts for.
+        :param flags:            Passed to the parameter flags in search_for().
+        :param max_match:        The number of matches to perform. 0 or
+                                 less would not limit the number of matches.
+        """
+        self.assertEqual(len(expected_strings), len(test_strings))
+        for i in range(0, len(expected_strings)):
+            return_value = search_for(pattern,
+                                      test_strings[i],
+                                      flags,
+                                      max_match)
+
+            # Check each MatchObject. Need to iterate over the return_value
+            # since the return value is an iterator object pointing to the
+            # MatchObject's.
+            n = 0
+            for x in return_value:
+                self.assertEqual(expected_strings[i][n], x.group(0))
+                n += 1
+
+            self.assertEqual(n, len(expected_strings[i]))
+
+    # Test the search_for() function.
+    def test_search_for(self):
+        search_pattern = self.test_search_for_pattern
+        expected_results = self.test_search_for_expected_results
+
+        self.assertSearchForResultEqual(search_pattern,
+                                        self.test_strings,
+                                        expected_results)
+
+    # Test search_for() with a simple pattern.
+    def test_search_for_simple_pattern(self):
+        search_pattern = self.test_search_for_simple_pattern_pattern
+        expected_results = self.test_search_for_simple_pattern_expected_results
+
+        self.assertSearchForResultEqual(search_pattern,
+                                        self.test_strings,
+                                        expected_results)
+
+    # Test search_for() with an empty pattern.
+    def test_search_for_empty_pattern(self):
+        search_pattern = self.test_search_for_empty_pattern_pattern
+        expected_results = self.test_search_for_empty_pattern_expected_results
+
+        self.assertSearchForResultEqual(search_pattern,
+                                        self.test_strings,
+                                        expected_results)
+
+    # Test search_for() for its max_match parameter.
+    def test_search_for_max_match(self):
+        search_pattern = self.test_search_for_max_match_pattern
+        expected_master_results = (
+            self.test_search_for_max_match_expected_master_result)
+
+        for i in [1, 2, 3, 4, 5, 6, 987, 100928321]:
+            expected_results = [
+                expected_master_results[j][0 : i]
+                for j in range(len(expected_master_results))]
+            self.assertSearchForResultEqual(search_pattern,
+                                            self.test_strings,
+                                            expected_results,
+                                            0,
+                                            i)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)
+

--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -4,6 +4,7 @@ import unittest
 
 from coalib.parsing.StringProcessing import search_for
 from coalib.parsing.StringProcessing import split
+from coalib.parsing.StringProcessing import unescaped_split
 
 
 class StringProcessingTest(unittest.TestCase):
@@ -63,6 +64,7 @@ class StringProcessingTest(unittest.TestCase):
         # Set up test dependent variables.
         self.setUp_search_for()
         self.setUp_split()
+        self.setUp_unescaped_split()
 
     def setUp_search_for(self):
         # Match either "out1" or "out2".
@@ -155,6 +157,60 @@ class StringProcessingTest(unittest.TestCase):
             [],
             [r"Hello world"],
             [self.bs],
+            [2 * self.bs],
+            [r"abc", r"a", r"asc"]]
+
+    def setUp_unescaped_split(self):
+        self.test_unescaped_split_pattern = "'"
+        self.test_unescaped_split_expected_results = [
+            [r"out1 ", r"escaped-escape:        \\ ", r" out2"],
+            [r"out1 ", r"escaped-quote:         \' ", r" out2"],
+            [r"out1 ", r"escaped-anything:      \X ", r" out2"],
+            [r"out1 ", r"two escaped escapes: \\\\ ", r" out2"],
+            [r"out1 ", r"escaped-quote at end:   \'", r" out2"],
+            [r"out1 ", r"escaped-escape at end:  " + 2 * self.bs, r" out2"],
+            [r"out1           ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \'        ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \\\'      ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \\        ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1 \\\\      ", r"str1", r" out2 ", r"str2", r" out2"],
+            [r"out1         " + 2 * self.bs, r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1       " + 4 * self.bs, r"str1", r" out2 ", r"str2",
+                r" out2"],
+            [r"out1           ", r"str1", r"", r"str2", r"", r"str3",
+                r" out2"],
+            [r""],
+            [r"out1 out2 out3"],
+            [self.bs],
+            [2 * self.bs]]
+
+        self.test_unescaped_split_max_split_pattern = (
+            self.test_unescaped_split_pattern)
+        self.test_unescaped_split_max_split_expected_master_results = (
+            self.test_unescaped_split_expected_results)
+
+        self.test_unescaped_split_regex_pattern_expected_results = [
+            [r"", r"", r"cba###\\13q4ujsabbc\+'**'ac###.#.####-ba"],
+            [r"", r"c", r"ccba###\\13q4ujs", r"bc\+'**'ac###.#.####-ba"],
+            [r"", r"c", r"ccba###\\13q4ujs", r"bc\+'**'", r"###.#.####-ba"],
+            [r"abcabccba###", r"\13q4ujsabbc", r"+'**'ac###.#.####-ba"],
+            [r"abcabccba", r"\\13q4ujsabbc\+'**'ac", r".", r".", r"-ba"],
+            [r"", r"", r"c", r"", r"cc", r"", r"", r"", r"\13q4ujs", r"", r"",
+                r"c\+'**'", r"c", r"", r"", r"", r"", r"-", r"", r""],
+            [r"", r"cba###\\13q4ujs", r"\+'**'", r"###.#.####-ba"],
+            [r"abcabccba###" + 2 * self.bs,
+                r"3q4ujsabbc\+'**'ac###.#.####-ba"]]
+
+        self.test_unescaped_split_auto_trim_pattern = ";"
+        self.test_unescaped_split_auto_trim_expected_results = [
+            [],
+            [2 * self.bs, r"\\\\\;\\#", r"\\\'", r"\;\\\\", r"+ios"],
+            [r"1", r"2", r"3", r"4", r"5", r"6"],
+            [r"1", r"2", r"3", r"4", r"5", r"6", r"7"],
+            [],
+            [r"Hello world"],
+            [r"\;"],
             [2 * self.bs],
             [r"abc", r"a", r"asc"]]
 
@@ -309,6 +365,73 @@ class StringProcessingTest(unittest.TestCase):
                                  self.auto_trim_test_strings[i],
                                  0,
                                  True)
+            self.assertIteratorElementsEqual(iter(expected_results[i]),
+                                             return_value)
+
+    # Test the basic unescaped_split() functionality.
+    def test_unescaped_split(self):
+        separator_pattern = self.test_unescaped_split_pattern
+        expected_results = self.test_unescaped_split_expected_results
+
+        self.assertEqual(len(expected_results), len(self.test_strings))
+        for i in range(0, len(expected_results)):
+            return_value = unescaped_split(separator_pattern,
+                                           self.test_strings[i])
+            self.assertIteratorElementsEqual(iter(expected_results[i]),
+                                             return_value)
+
+    # Test the unescaped_split() function while varying the max_split
+    # parameter.
+    def test_unescaped_split_max_split(self):
+        separator_pattern = self.test_unescaped_split_max_split_pattern
+        expected_master_results = (
+            self.test_unescaped_split_max_split_expected_master_results)
+
+        for max_split in [1, 2, 3, 4, 5, 6, 7, 8, 9, 99918829]:
+            expected_results = [
+                expected_master_results[j][0 : max_split]
+                for j in range(len(expected_master_results))]
+
+            for j in range(len(expected_master_results)):
+                if max_split < len(expected_master_results[j]):
+                    # max_split is less the length of our master result list,
+                    # need to append the rest as a joined string.
+                    expected_results[j].append(
+                        str.join(separator_pattern,
+                                 expected_master_results[j][max_split : ]))
+
+            self.assertEqual(len(expected_results), len(self.test_strings))
+            for x in range(0, len(expected_results)):
+                return_value = unescaped_split(separator_pattern,
+                                               self.test_strings[x],
+                                               max_split)
+                self.assertIteratorElementsEqual(iter(expected_results[x]),
+                                                 return_value)
+
+    # Test the unescaped_split() function with different regex patterns.
+    def test_unescaped_split_regex_pattern(self):
+        expected_results = (
+            self.test_unescaped_split_regex_pattern_expected_results)
+
+        self.assertEqual(len(expected_results), len(self.multi_patterns))
+        for i in range(0, len(expected_results)):
+            return_value = unescaped_split(self.multi_patterns[i],
+                                           self.multi_pattern_test_string)
+            self.assertIteratorElementsEqual(iter(expected_results[i]),
+                                             return_value)
+
+    # Test the unescaped_split() function for its remove_empty_matches feature.
+    def test_unescaped_split_auto_trim(self):
+        separator = self.test_unescaped_split_auto_trim_pattern
+        expected_results = self.test_unescaped_split_auto_trim_expected_results
+
+        self.assertEqual(len(expected_results),
+                         len(self.auto_trim_test_strings))
+        for i in range(0, len(expected_results)):
+            return_value = unescaped_split(separator,
+                                           self.auto_trim_test_strings[i],
+                                           0,
+                                           True)
             self.assertIteratorElementsEqual(iter(expected_results[i]),
                                              return_value)
 


### PR DESCRIPTION
Takes over as v3 from #364.

Main changes:
- Restructurized test data/results (each function under test got an own `setUp` function), so code duplication is minimized and also test results are easier to oversee and edit.
- Tests: Added some test strings/cases
- `search_for()`: removed `max_match` parameter, since it's not needed because of the generator behaviour.
And because of that it became just a forwarding function for `re.finditer()`.
- `search_in_between()`/`unescaped_search_in_between()`: Filter generators for easier matching algorithm.
