### PR TITLE
Adding HTML Log printer feature

### DIFF
--- a/coalib/output/printers/HTMLPrinter.py
+++ b/coalib/output/printers/HTMLPrinter.py
@@ -1,0 +1,70 @@
+from coalib.output.printers.LogPrinter import LogPrinter
+from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
+from coalib.output.printers.HTMLWriter import HTMLWriter
+
+class HTMLPrinter(LogPrinter):
+    """
+    This is a simple printer/logprinter that prints everything to an HTML file. Note that everything will be appended.
+    """
+    def __init__(self, filename, log_level=LOG_LEVEL.WARNING, timestamp_format="%X"):
+        """
+        Creates a new HTMLPrinter. If the directory of the given file doesn't exist or if there's any access problems,
+        an exception will be thrown.
+
+        :param filename: the name of the file to put the data into (string).
+        """
+        self.file = None
+        self.log_level = log_level
+        if not isinstance(filename, str):
+            raise TypeError("filename must be a string.")
+
+        LogPrinter.__init__(self, timestamp_format=timestamp_format, log_level=log_level)
+        #self.file = open(filename, 'a+')
+        self.htmlwriter = HTMLWriter(filename)
+        self.htmlwriter.write_tags
+
+    def __del__(self):
+        if self.file is not None:
+            self.file.close()
+
+    def _get_log_prefix(self, log_level, timestamp):
+        self.log_level = LOG_LEVEL.reverse.get(log_level, "ERROR")
+
+    def _print(self, *args, delimiter=' ', end='\n', color=None, log_date=True):
+        if self.log_level == LOG_LEVEL.reverse.get(LOG_LEVEL.WARNING):
+            color = "Yellow"
+        if self.log_level == LOG_LEVEL.reverse.get(LOG_LEVEL.ERROR):
+            color = "Red"
+        if self.log_level == LOG_LEVEL.reverse.get(LOG_LEVEL.DEBUG):
+            color = "Blue"
+
+        if color is None:
+            self.__print_without_color(*args, delimiter=delimiter, end=end)
+        else:
+            self.__print_with_color(color, *args, delimiter=delimiter, end=end)
+
+    def __print_without_color(self, *args, delimiter, end):
+        output = ""
+        for arg in args:
+            if output != "":
+                output += delimiter
+            output += arg
+
+        if end == '\n':
+            self.htmlwriter.write_tags(p=output)
+            return
+
+        self.htmlwriter.write_tags(span=output+end)
+
+    def __print_with_color(self, color, *args, delimiter, end):
+        output = ""
+        for arg in args:
+            if output != "":
+                output += delimiter
+            output += arg
+
+        if end == '\n':
+            self.htmlwriter.write_tag("p", output, style="color:{}".format(color))
+            return
+
+        self.htmlwriter.write_tags(span=output+end)

--- a/coalib/output/printers/HTMLWriter.py
+++ b/coalib/output/printers/HTMLWriter.py
@@ -1,0 +1,101 @@
+class HTMLWriter:
+    """
+    Printer for outputting HTML Log files.
+
+    :raises TypeError: If directory of given file doesn't exist or in case of
+    access problems
+
+    :param filename:            the name of the file to put the data into (string).
+    :param indentation_per_tag: spaces used to indent every subsequent HTML tag
+    """
+
+    def __init__(self, filename, indentation_per_tag=2, indentation=0):
+        self.indentation_per_tag = indentation_per_tag
+        self.indentation = indentation
+        self.file = None
+        self.filename = filename
+
+        if not isinstance(filename, str):
+            raise TypeError("filename must be a string")
+
+        self.file = open(filename, 'w+')
+        self.__write_header()
+
+
+    def __del__(self):
+        if self.file is not None:
+            self.__write_footer()
+            self.file.close()
+
+    def __write_header(self):
+        self.write("<!DOCTYPE html>")
+        self.open_tag("html")
+
+    def __write_footer(self):
+        self.close_tag("html")
+
+    def write_comment(self, *comments):
+        """
+
+        :param comments: string denoting the comment to be inserted
+        """
+        for comment in comments:
+            self.write("<!-- " + comment + " -->")
+
+    def write_tag(self, tag, content="", **tagargs):
+        """
+
+        :param tag:     HTML Tag for formatting the content
+        :param content: content to output into the HTML Log file
+        :param tagargs: attributes to the HTML tag param
+        """
+        name = tag
+        for arg in tagargs:
+            name += " " + arg + "=\"" + tagargs[arg] + "\""
+
+        if content == "":
+            self.write("<"+name+"/>")
+            return
+
+        self.open_tag(name)
+        self.write(content)
+        self.close_tag(tag)
+
+    def write_tags(self, **tags):
+        """
+
+        :param tags: dict(HTML tag name: HTML content): mapping of HTML tag to its content
+        """
+        for tag in tags:
+            content = tags[tag]
+            if not content:
+                self.write("<"+tag+"/>")
+                continue
+
+            self.open_tag(tag)
+            self.write(content)
+            self.close_tag(tag)
+
+    def open_tag(self, tag_name):
+        """
+
+        :param tag_name: the name of HTML Tag to written in the output logfile
+        """
+        self.write("<"+tag_name+">")
+        self.indentation += 4
+
+    def close_tag(self, tag_name):
+        """
+
+        :param tag_name: the name of HTML Tag to be written to output logfile
+        """
+        self.indentation -= 4
+        self.write("</"+tag_name+">")
+
+    def write(self, *args):
+        """
+
+        :param args: arbitrary number of arguments to be written to output logfile
+        """
+        for line in args:
+            self.file.write(" "*self.indentation + line + "\n")

--- a/coalib/tests/output/printers/HTMLPrinterTest.py
+++ b/coalib/tests/output/printers/HTMLPrinterTest.py
@@ -1,0 +1,34 @@
+import sys
+import tempfile
+import os
+import unittest
+
+sys.path.insert(0, ".")
+from coalib.output.printers.HTMLPrinter import HTMLPrinter
+
+
+class HTMLPrinterTestCase(unittest.TestCase):
+    def setUp(self):
+        handle, self.filename = tempfile.mkstemp()
+        os.close(handle)  # We don't need the handle provided by mkstemp
+        self.uut = HTMLPrinter(self.filename)
+
+    def tearDown(self):
+        os.remove(self.filename)
+
+    def test_construction(self):
+        self.assertRaises(TypeError, HTMLPrinter, 5)
+
+    def test_printing(self):
+        self.uut = HTMLPrinter(self.filename)
+
+        with open(self.filename) as file:
+            lines = file.readlines()
+
+        self.assertEqual(lines,
+                         ['<!DOCTYPE html>\n',
+                          '<html>\n',
+                          '</html>\n'])
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/coalib/tests/output/printers/HTMLWriterTest.py
+++ b/coalib/tests/output/printers/HTMLWriterTest.py
@@ -1,0 +1,70 @@
+import re
+import sys
+import os
+import tempfile
+
+sys.path.insert(0, ".")
+from coalib.output.printers.HTMLWriter import HTMLWriter
+import unittest
+
+
+class HTMLWriterTest(unittest.TestCase):
+    def setUp(self):
+        handle, self.filename = tempfile.mkstemp()
+        os.close(handle)  # We don't need the handle provided by mkstemp
+        self.uut = HTMLWriter(self.filename)
+
+    def tearDown(self):
+        os.remove(self.filename)
+
+    def test_construction(self):
+        self.assertRaises(TypeError, HTMLWriter, 5)
+        with open(self.filename) as file:
+            lines = file.readlines()
+        self.assertEqual(lines, [])
+        del self.uut
+
+    def test_printing_header_footer(self):
+        self.uut = HTMLWriter(self.filename)
+        with open(self.filename) as file:
+            lines = file.readlines()
+        self.assertEqual(lines,
+                        ['<!DOCTYPE html>\n',
+                         '<html>\n',
+                         '</html>\n'])
+
+        del self.uut
+
+    def test_write_comment(self):
+        self.uut = HTMLWriter(self.filename)
+        self.uut.write_comment("testing comments")
+        del self.uut
+        with open(self.filename) as file:
+            lines = file.readlines()
+
+        self.assertEqual(lines,
+                         ['<!DOCTYPE html>\n',
+                          '<html>\n',
+                          '    <!-- testing comments -->\n',
+                          '</html>\n'])
+
+    def test_write_tags(self):
+        self.uut = HTMLWriter(self.filename)
+        self.tag_dict = {'p':'test'}
+        self.uut.write_tags(**self.tag_dict)
+        del self.uut
+
+        with open(self.filename) as file:
+            lines = file.readlines()
+
+        self.assertEqual(lines,
+                         ['<!DOCTYPE html>\n',
+                          '<html>\n',
+                          '    <p>\n',
+                          '        test\n',
+                          '    </p>\n',
+                          '</html>\n'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This is a WIP, a basic layout for an HTML Printer.
It highlights different color for the basic log_types : 
- WARNING (yellow)
- ERROR (red) 
- DEBUG (blue)

Addresses : #294 

TODO - Adapt it into a prettier template