### PR TITLE
TestHelper: Show error on passing invalid tests

### DIFF
--- a/coalib/tests/TestHelper.py
+++ b/coalib/tests/TestHelper.py
@@ -112,7 +112,7 @@ class TestHelper:
                 nonexistent_tests += 1
                 self.failed_tests += 1
                 print(" {:>2}/{:<2} | {}, Cannot execute: This test does "
-                      "not exist.".format(j, number, test))
+                      "not exist.".format(nonexistent_tests, number, test))
 
         return nonexistent_tests, number
 

--- a/coalib/tests/TestHelper.py
+++ b/coalib/tests/TestHelper.py
@@ -80,7 +80,7 @@ class TestHelper:
             self.delete_coverage()
 
         if len(self.args.test_only) > 0:
-            nonexistent_tests, number = self.show_nonexistent_test()
+            nonexistent_tests, number = self.show_nonexistent_tests()
         else:
             number = len(self.test_files)
             nonexistent_tests = 0
@@ -113,6 +113,7 @@ class TestHelper:
                 self.failed_tests += 1
                 print(" {:>2}/{:<2} | {}, Cannot execute: This test does "
                       "not exist.".format(j, number, test))
+
         return nonexistent_tests, number
 
     def add_test_files(self, testdir):


### PR DESCRIPTION
Changed method definition in run_tests() from show_nonexistent_test()
to show_nonexistent_tests(). In the method show_nonexistent_tests()
change the j variable to nonexistent_tests.

Fixes: https://github.com/coala-analyzer/coala/issues/384