### PR TITLE
clang: Correct import

### DIFF
--- a/.ci_coafile
+++ b/.ci_coafile
@@ -3,3 +3,8 @@ output = none
 bears = SpaceConsistencyBear, LineLengthBear
 use_spaces = True
 max_line_length = 80
+
+[DOCS]
+bears = SpaceConsistencyBear
+files = doc/**/*.md
+use_spaces = True

--- a/.coafile
+++ b/.coafile
@@ -1,6 +1,7 @@
 # So all sections are disabled by default
 Default.enabled = false
 PythonCheck.enabled = true
+DOCS.enabled = true
 
 [Default]
 files = *.py, bears/**/*.py, coalib/**/*.py, ./coala
@@ -17,3 +18,8 @@ bears = LineCountBear
 bears = KeywordBear
 ci_keywords = \#TODO, \# TODO, \#FIXME, \# FIXME
 cs_keywords =
+
+[DOCS]
+bears = SpaceConsistencyBear
+files = doc/**/*.md
+use_spaces = True

--- a/coalib/bearlib/parsing/clang/README.md
+++ b/coalib/bearlib/parsing/clang/README.md
@@ -3,7 +3,7 @@
 These are the clang bindings for python 3 taken from:
 These are from https://github.com/kennytm/clang-cindex-python3
 
-Only spacing modifications were done to comply with coalas codestyle.
+Minor modifications were done.
 
 # License
 

--- a/coalib/bearlib/parsing/clang/cindex.py
+++ b/coalib/bearlib/parsing/clang/cindex.py
@@ -65,7 +65,7 @@ call is efficient.
 from ctypes import *
 import collections
 
-import clang.enumerations
+from coalib.bearlib.parsing.clang import enumerations
 
 # ctypes doesn't implicitly convert c_void_p to the appropriate wrapper
 # object. This is a problem, because it means that from_parameter will see an
@@ -3142,7 +3142,7 @@ class Config:
         return True
 
 def register_enumerations():
-    for name, value in clang.enumerations.TokenKinds:
+    for name, value in enumerations.TokenKinds:
         TokenKind.register(value, name)
 
 conf = Config()

--- a/doc/Exit_Codes.md
+++ b/doc/Exit_Codes.md
@@ -5,11 +5,11 @@ The following is a list of the exit codes and their meanings in the coala code:
  * `0` - coala executed succesfully but yielded no results.
  * `1` - coala executed succesfully but yielded results.
  * `2` - Invalid arguments were passed to coala in the command line.
- * `3` - The file collector exits with this code if an invalid pattern is 
+ * `3` - The file collector exits with this code if an invalid pattern is
    passed to it.
- * `130` - A KeyboardInterrupt(Ctrl+C) was pressed during the execution of 
+ * `130` - A KeyboardInterrupt (Ctrl+C) was pressed during the execution of
    coala.
  * `255` - Any other general errors.
- 
-This list will be updated regularly as and when new exit codes are added to 
+
+This list will be updated regularly as and when new exit codes are added to
 coala.

--- a/doc/General_Dev_Info/git_tutorial_1.md
+++ b/doc/General_Dev_Info/git_tutorial_1.md
@@ -135,7 +135,7 @@ vim is and how to operate it, let's **change the editor**:
 
 ```
 $ # Take an editor of your choice instead of nano
-$ git config --global core.editor nano 
+$ git config --global core.editor nano
 ```
 
 Please make sure that the **command** you give to git always **starts as an own
@@ -202,7 +202,7 @@ Initial commit
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
 
-	README
+    README
 
 nothing added to commit but untracked files present (use "git add" to track)
 $ git add README
@@ -214,7 +214,7 @@ Initial commit
 Changes to be committed:
   (use "git rm --cached <file>..." to unstage)
 
-	new file:   README
+    new file:   README
 
 ```
 
@@ -359,7 +359,7 @@ We just saw the **ID** of the commit we made:
 Now let's see if we find it in the objects directory:
 
 ```
-$ ls .git/objects 
+$ ls .git/objects
 98/  b4/  ec/  info/  pack/
 $ ls .git/objects/ec
 6c903a0a18960cd73df18897e56738c4c6bb51


### PR DESCRIPTION
clang used an absolute import which isn't valid within the coala source
tree. With this the clang library can finally be used.