### PR TITLE
Last piece of windows compatability

### DIFF
--- a/appveyor/appveyor.yml
+++ b/appveyor/appveyor.yml
@@ -1,0 +1,33 @@
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+
+  matrix:
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4"
+      PYTHON_ARCH: "64"
+
+install:
+  # Prepend newly installed Python to the PATH of this build (this cannot be
+  # done from inside the powershell script as it would require to restart
+  # the parent CMD process).
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  - "%CMD_IN_ENV% pip install coverage"
+
+build: false  # Not a C# project, build stuff at the test step instead.
+
+test_script:
+  - "%CMD_IN_ENV% python run_tests.py --cover"
+  - "%CMD_IN_ENV% python setup.py install"

--- a/appveyor/appveyor.yml
+++ b/appveyor/appveyor.yml
@@ -6,6 +6,14 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:
+    - PYTHON: "C:\\Python33"
+      PYTHON_VERSION: "3.3"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python33-x64"
+      PYTHON_VERSION: "3.3"
+      PYTHON_ARCH: "64"
+
     - PYTHON: "C:\\Python34"
       PYTHON_VERSION: "3.4"
       PYTHON_ARCH: "32"

--- a/appveyor/run_with_env.cmd
+++ b/appveyor/run_with_env.cmd
@@ -1,0 +1,47 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds do not require specific environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+
+SET MAJOR_PYTHON_VERSION="%PYTHON_VERSION:~0,1%"
+IF %MAJOR_PYTHON_VERSION% == "2" (
+    SET WINDOWS_SDK_VERSION="v7.0"
+) ELSE IF %MAJOR_PYTHON_VERSION% == "3" (
+    SET WINDOWS_SDK_VERSION="v7.1"
+) ELSE (
+    ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+    EXIT 1
+)
+
+IF "%PYTHON_ARCH%"=="64" (
+    ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+    SET DISTUTILS_USE_SDK=1
+    SET MSSdk=1
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/coalib/processes/SectionExecutor.py
+++ b/coalib/processes/SectionExecutor.py
@@ -112,7 +112,7 @@ class SectionExecutor:
         running_processes = self._get_running_processes(processes)
         retval = False
         # Number of processes working on local bears
-        local_processes = running_processes
+        local_processes = len(processes)
         global_result_buffer = []
 
         # One process is the logger thread

--- a/coalib/tests/processes/SectionExecutorTest.py
+++ b/coalib/tests/processes/SectionExecutorTest.py
@@ -95,8 +95,8 @@ class SectionExecutorTest(unittest.TestCase):
         self.testcode_c_path = os.path.join(os.path.dirname(config_path),
                                             "testcode.c")
 
-        self.sections, self.local_bears, self.global_bears, targets \
-            = SectionManager().run(["--config", re.escape(config_path)])[0:4]
+        self.sections, self.local_bears, self.global_bears, targets = (
+            SectionManager().run(["--config", re.escape(config_path)])[0:4])
         self.assertEqual(len(self.local_bears["default"]), 1)
         self.assertEqual(len(self.global_bears["default"]), 1)
         self.assertEqual(targets, [])

--- a/coalib/tests/processes/SectionExecutorTest.py
+++ b/coalib/tests/processes/SectionExecutorTest.py
@@ -11,6 +11,7 @@ from coalib.output.printers.LogPrinter import LogPrinter
 from coalib.processes.SectionExecutor import SectionExecutor
 from coalib.output.printers.ConsolePrinter import ConsolePrinter
 from coalib.processes.CONTROL_ELEMENT import CONTROL_ELEMENT
+import re
 
 
 class SectionExecutorTestInteractor(Interactor, LogPrinter):
@@ -94,7 +95,7 @@ class SectionExecutorTest(unittest.TestCase):
                                             "testcode.c")
 
         self.sections, self.local_bears, self.global_bears, targets \
-            = SectionManager().run(["--config", config_path])[0:4]
+            = SectionManager().run(["--config", re.escape(config_path)])[0:4]
         self.assertEqual(len(self.local_bears["default"]), 1)
         self.assertEqual(len(self.global_bears["default"]), 1)
         self.assertEqual(targets, [])

--- a/coalib/tests/processes/SectionExecutorTest.py
+++ b/coalib/tests/processes/SectionExecutorTest.py
@@ -55,17 +55,18 @@ class ProcessQueuesTestSectionExecutor(SectionExecutor):
                        control_queue,
                        local_result_dict,
                        global_result_dict):
-        # Pass control_queue as processes
-        self._process_queues(control_queue,
+        self.control_queue = control_queue
+        # _process_queues() will only use len() to determine the number of
+        # processes. So just fill with an empty list with three elements.
+        self._process_queues([None for i in range(3)],
                              control_queue,
                              local_result_dict,
                              global_result_dict,
                              None)
 
-    @staticmethod
-    def _get_running_processes(processes):
+    def _get_running_processes(self, processes):
         # Two processes plus one logger process until no commands are left.
-        return 0 if processes.empty() else 3
+        return 0 if self.control_queue.empty() else 3
 
 
 class MessageQueueingInteractor(Interactor):

--- a/coalib/tests/settings/SectionManagerTest.py
+++ b/coalib/tests/settings/SectionManagerTest.py
@@ -15,6 +15,7 @@ from coalib.output.printers.ConsolePrinter import ConsolePrinter
 from coalib.output.printers.FilePrinter import FilePrinter
 from coalib.output.printers.NullPrinter import NullPrinter
 from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
+import re
 
 
 class SectionManagerTest(unittest.TestCase):
@@ -83,14 +84,14 @@ class SectionManagerTest(unittest.TestCase):
             "section_manager_test_files",
             ".coafile"))
         # Check merging of default_coafile and .coafile
-        conf_sections = uut.run(arg_list=["-c", config])[0]
+        conf_sections = uut.run(arg_list=["-c", re.escape(config)])[0]
         self.assertEqual(str(conf_sections["test"]),
                          "test {value : 2}")
         self.assertEqual(str(conf_sections["test-2"]),
                          "test-2 {files : ., bears : LineCountBear}")
         # Check merging of default_coafile, .coafile and cli
         conf_sections = uut.run(arg_list=["-c",
-                                          config,
+                                          re.escape(config),
                                           "-S",
                                           "test.value=3",
                                           "test-2.bears=",
@@ -122,7 +123,9 @@ class SectionManagerTest(unittest.TestCase):
 
         # We need to use a bad filename or this will parse coalas .coafile
         SectionManager().run(
-            arg_list=['-S', "save=" + filename, "-c", "some_bad_filename"])
+            arg_list=['-S',
+                      "save=" + re.escape(filename),
+                      "-c=some_bad_filename"])
 
         with open(filename, "r") as f:
             lines = f.readlines()
@@ -130,7 +133,10 @@ class SectionManagerTest(unittest.TestCase):
                          lines)
 
         SectionManager().run(
-            arg_list=['-S', "save=true", "config=" + filename, "test.value=5"])
+            arg_list=['-S',
+                      "save=true",
+                      "config=" + re.escape(filename),
+                      "test.value=5"])
 
         with open(filename, "r") as f:
             lines = f.readlines()
@@ -185,7 +191,7 @@ class SectionManagerTest(unittest.TestCase):
 
         filename = tempfile.gettempdir() + os.path.sep + "log_test~"
         test_section = Section("default")
-        test_section.append(Setting(key="log_TYPE", value=filename))
+        test_section.append(Setting(key="log_TYPE", value=re.escape(filename)))
         uut.retrieve_logging_objects(test_section)
         self.assertIsInstance(uut.log_printer, FilePrinter)
         uut.log_printer.close()

--- a/coalib/tests/settings/SettingTest.py
+++ b/coalib/tests/settings/SettingTest.py
@@ -9,6 +9,7 @@ from coalib.settings.Setting import (Setting,
                                      path_list,
                                      typed_list,
                                      typed_dict)
+import re
 
 
 class SettingTest(unittest.TestCase):
@@ -22,7 +23,7 @@ class SettingTest(unittest.TestCase):
                          os.path.abspath(os.path.join(".", "22")))
 
         abspath = os.path.abspath(".")
-        self.uut = Setting("key", abspath)
+        self.uut = Setting("key", re.escape(abspath))
         self.assertEqual(path(self.uut), abspath)
 
         self.uut = Setting("key", " 22", "")


### PR DESCRIPTION
Appends the python file extension to coala. This allows Windows users
to run coala from command line if they have python in their PATH.
Also using the ".py" file extension is more consequent for python
files.