### PR TITLE
writing-tests-guide: Improve kickstart

### DIFF
--- a/doc/Getting_Involved/Writing_Tests.md
+++ b/doc/Getting_Involved/Writing_Tests.md
@@ -324,6 +324,7 @@ modify it to let it test your stuff and run from the coala root folder
 import sys
 import unittest
 
+sys.path.insert(0, ".")
 # Import here your needed coala components.
 
 


### PR DESCRIPTION
Missing the sys.path.insert() statement before the coala imports.