### PR TITLE
.gitignore: Ignore Kdevelop4 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.directory
 .idea
+.kdev4
 __pycache__
 *~
 build
@@ -13,4 +15,5 @@ coverage.xml
 .htmlreport
 *.orig
 *.diff
+*.kdev4
 *.patch


### PR DESCRIPTION
This prevents files generated automatically by Kdevelop to be committed by accident. It is inline with the suppression of the PyCharm .idea files.