### PR TITLE
DbusDocument: Add special handling for empty path

### DIFF
--- a/coalib/output/dbus/DbusDocument.py
+++ b/coalib/output/dbus/DbusDocument.py
@@ -36,6 +36,9 @@ class DbusDocument(dbus.service.Object):
 
         :return: The config file path
         """
+        if self.path == "":
+            return ""
+
         self.config_file = find_user_config(self.path)
         return self.config_file
 

--- a/coalib/tests/output/dbus/DbusDocumentTest.py
+++ b/coalib/tests/output/dbus/DbusDocumentTest.py
@@ -26,8 +26,11 @@ class DbusDocumentTest(unittest.TestCase):
         self.assertEqual(uut.path, os.path.abspath(test_file))
 
     def test_config(self):
-        uut = DbusDocument("dummy_path")
+        uut = DbusDocument(id=1)
         self.assertEqual(uut.FindConfigFile(), "")
+
+        uut.path = self.testcode_c_path
+        self.assertEqual(uut.FindConfigFile(), self.config_path)
 
         uut.SetConfigFile("config_file")
         self.assertEqual(uut.config_file, "config_file")


### PR DESCRIPTION
Fix for the issue brought up in https://github.com/coala-analyzer/coala/commit/240557a30a40ef1052f045b7a9eccbc2f2f81b61