### PR TITLE
circle: Move zanata upload to rultor

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,3 +1,4 @@
 merge:
   script:
-    - bash .misc/fail_if_HEAD_is_merge.sh
+    - "bash .misc/fail_if_HEAD_is_merge.sh"
+    - "bash .misc/.deploy.zanata.sh"

--- a/circle.yml
+++ b/circle.yml
@@ -21,9 +21,3 @@ test:
   post:
     - sh .misc/.success.coverage.sh:
         parallel: true
-
-deployment:
-  translation:
-    branch: master
-    commands:
-      - sh .misc/.deploy.zanata.sh


### PR DESCRIPTION
We may rebuild old builds on master, we only want to upload that kind of
stuff when we merge to master so rultor is the option for that.