### PR TITLE
circleci: Remove python-tmpenv

### DIFF
--- a/.misc/.install.python-dbus.sh
+++ b/.misc/.install.python-dbus.sh
@@ -10,23 +10,16 @@ echo Unpacking python-dbus...
 tar -zxvf dbus-python.tar.gz > /dev/null
 rm dbus-python.tar.gz
 
-mkdir -p python-tmpenv
-
 if [ "$CIRCLECI" = "true" ] ; then
   python_virtualenv=`pyenv prefix`
 else
   python_virtualenv=$VIRTUAL_ENV
 fi
 
-python_tmpenv=`pwd`/python-tmpenv
-
 cd dbus-python-1.2.0
 
-PYTHON=`sudo which ${system_python}` ./configure --prefix=$python_tmpenv
+PYTHON=`sudo which ${system_python}` ./configure --prefix=$python_virtualenv
 make
 make install
 
 cd ..
-
-echo Copying files from the temporary python env to the virtualenv
-cp -r $python_tmpenv/* $python_virtualenv

--- a/.misc/.install.python-gi.sh
+++ b/.misc/.install.python-gi.sh
@@ -11,10 +11,7 @@ echo Unpacking python-gi...
 tar -xJf python-gi.tar.xz > /dev/null
 rm python-gi.tar.xz
 
-mkdir -p python-tmpenv
-
 python_virtualenv=`pyenv prefix`
-
 cd pygobject-3.16.2
 
 PYTHON=`sudo which ${system_python}` ./configure --prefix=$python_virtualenv


### PR DESCRIPTION
Earlier packages like python-gi and python-dbus were installed in a
temporary python environment and then moved to the actual virtualenv.
This commit removes the need for the tmpenv and directly installs it in
the virtualenv.