### PR TITLE
Add coala main file

### DIFF
--- a/coala
+++ b/coala
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License
+# for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+
+from coalib.coala import main
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This makes it easy to execute the local coala version for development.
Also it fixes the deployment step which is currently failing on master
because of this file missing.