### PR TITLE
circleci: Add pypi deployment

### DIFF
--- a/.misc/deploy.pypi.sh
+++ b/.misc/deploy.pypi.sh
@@ -1,0 +1,15 @@
+set -e
+# Do not use `set -x` here as then it displays the PYPIPW in circleci logs
+
+if [ "$CIRCLE_BRANCH" = "master" ] ; then
+  echo "[distutils]
+  index-servers=pypi
+  [pypi]
+  repository = https://pypi.python.org/pypi
+  username = $PYPIUSER
+  password = $PYPIPW" > ~/.pypirc
+  echo Deploying coala `coala -v`...
+  python setup.py register
+  python setup.py sdist upload
+  rm ~/.pypirc
+fi

--- a/circle.yml
+++ b/circle.yml
@@ -20,3 +20,4 @@ deployment:
     branch: /.*/
     commands:
       - bash .misc/deploy.zanata.sh
+      - bash .misc/deploy.pypi.sh


### PR DESCRIPTION
This will deploy automatically from master to pypi making the most
recent coala version available easily.