### PR TITLE
coverage: Use future codecov

### DIFF
--- a/.misc/deploy.coverage.sh
+++ b/.misc/deploy.coverage.sh
@@ -4,5 +4,5 @@ set -e
 source .misc/env_variables.sh
 
 if [ "$python_implementation" == "CPython" ] ; then
-  codecov
+  bash <(curl -s https://codecov.io/bash)
 fi

--- a/.misc/deps.sh
+++ b/.misc/deps.sh
@@ -8,7 +8,7 @@ sudo apt-get -qq install espeak libclang1-3.4
 sudo apt-get -qq install libdbus-glib-1-dev # for python-dbus
 sudo apt-get -qq install glib2.0-dev gobject-introspection libgirepository1.0-dev python3-cairo-dev # for python-gi
 
-pip install -q setuptools codecov munkres3
+pip install -q setuptools coverage munkres3
 
 cd .misc
 if [ "$python_implementation" == "CPython" ] ; then

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ test:
         parallel: true
     - coala-ci:
         parallel: true
-    - codecov:
+    - bash .misc/deploy.coverage.sh:
         parallel: true
 
 deployment:

--- a/coalib/parsing/ConfParser.py
+++ b/coalib/parsing/ConfParser.py
@@ -8,7 +8,7 @@ from coalib.settings.Section import Section
 
 
 class ConfParser:
-    if sys.version_info < (3, 3):  # pragma: no cover
+    if sys.version_info < (3, 3):
         FileNotFoundError = IOError
     else:
         FileNotFoundError = FileNotFoundError

--- a/docs/Getting_Involved/Review.md
+++ b/docs/Getting_Involved/Review.md
@@ -34,8 +34,7 @@ apply:
  * The build/tests pass on all services. (circleci, appveyor)
  * Scrutinizer shows passed. (That is: no new issues, no new classes with rating
    D or worse, project quality metric may only get better.)
- * The branch coverage stays or raises, implies all statements covered.
-   (codecov.io)
+ * All statements and branches are covered by your tests. (codecov.io)
 
 The coverage values may go down by a commit, however this is to be avoided.
 Tests must work for every commit.

--- a/docs/Getting_Involved/Testing.md
+++ b/docs/Getting_Involved/Testing.md
@@ -10,3 +10,5 @@ tests with our `./run_tests.py` script and report any errors you get!
 
 If you need more options about allowing skipped tests, getting code coverage
 displayed or omitting/selecting tests, just query `./run_tests.py --help`.
+Please note that you will not get a test coverage of 100% - the coverage on the
+website is merged for several python versions.

--- a/docs/Getting_Involved/Writing_Tests.md
+++ b/docs/Getting_Involved/Writing_Tests.md
@@ -143,17 +143,23 @@ if __name__ == '__main__':
 >
 > Tests in coala are evaluated against their coverage, means how many
 > statements will be executed from your component when invoking your test
-> cases. You should aim at a branch coverage of 100%.
+> cases. A branch coverage of 100% is needed for any commit in order to be
+> pushed to master - please ask us on gitter if you need help raising your
+> coverage!
 >
-> The branch coverage can be measured with the `./run_tests.py -c` command.
-> Even more information is available with the `-H` parameter. In order for this
-> to work you will need to have the coverage3 binary installed. It usually
-> comes with a package named `python-coverage3` or similar. Make sure that you
-> installed the version for python 3 and not the one for python 2!
+> The branch coverage can be measured locally with the `./run_tests.py -c`
+> command. Even more information is available with the `-H` parameter. In
+> order for this to work you will need to have the coverage3 binary
+> installed. It usually comes with a package named `python-coverage3` or
+> similar. Make sure that you installed the version for python 3 and not the
+> one for python 2! As our coverage is measured across builds against
+> several python versions (we need version specific branches here and there)
+> you will not get the full coverage locally! Simply make a pull request to
+> get the coverage measured automatically.
 >
 > If some code is untestable, you need to mark your component code with
 > `# pragma: no cover`. Important: Provide a reason why your code is
-> untestable.
+> untestable. Code coverage is measured using python 3.2, 3.3 and 3.4 on linux.
 >
 > ```python
 > # Reason why this function is untestable.
@@ -161,8 +167,6 @@ if __name__ == '__main__':
 >     # Untestable code.
 >     pass
 > ```
->
-> Code coverage is measured using python 3.4.
 
 # `setUp()` and `tearDown()`
 


### PR DESCRIPTION
This is the most up to date uploader at any time and it fiddles with the
coverage data and should allow us to finally remove platform dependent
no covers.