### PR TITLE
Refactor warnings when no coafile existent - see #367

### DIFF
--- a/coalib/misc/StringConverter.py
+++ b/coalib/misc/StringConverter.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import Iterable, OrderedDict
 import re
 from coalib.misc.StringConstants import StringConstants
 from coalib.parsing.StringProcessing import unescaped_split, unescape
@@ -19,10 +19,8 @@ class StringConverter:
         if list_delimiters is None:
             list_delimiters = [",", ";"]
 
-        if (
-                not isinstance(list_delimiters, list) and
-                not isinstance(list_delimiters, str)):
-            raise TypeError("list_delimiters has to be a string or a list")
+        if not isinstance(list_delimiters, Iterable):
+            raise TypeError("list_delimiters has to be an Iterable.")
         if not isinstance(strip_whitespaces, bool):
             raise TypeError("strip_whitespaces has to be a bool parameter")
 

--- a/coalib/parsing/CliParsing.py
+++ b/coalib/parsing/CliParsing.py
@@ -10,10 +10,10 @@ from coalib.parsing.DefaultArgParser import default_arg_parser
 def parse_cli(arg_list=sys.argv[1:],
               origin=os.getcwd(),
               arg_parser=default_arg_parser(),
-              key_value_delimiters=['=', ':'],
-              comment_seperators=[],
-              key_delimiters=[','],
-              section_override_delimiters=["."]):
+              key_value_delimiters=('=', ':'),
+              comment_seperators=(),
+              key_delimiters=(',',),
+              section_override_delimiters=(".",)):
     """
     Parses the CLI arguments and creates sections out of it.
 

--- a/coalib/parsing/LineParser.py
+++ b/coalib/parsing/LineParser.py
@@ -4,11 +4,11 @@ from coalib.parsing.StringProcessing import unescape
 
 class LineParser:
     def __init__(self,
-                 key_value_delimiters=['='],
-                 comment_seperators=['#', ';', '//'],
-                 key_delimiters=[','],
-                 section_name_surroundings={'[': "]"},
-                 section_override_delimiters=["."]):
+                 key_value_delimiters=('=',),
+                 comment_seperators=('#', ';', '//'),
+                 key_delimiters=(',',),
+                 section_name_surroundings=None,
+                 section_override_delimiters=(".",)):
         """
         Creates a new line parser. Please note that no delimiter or seperator
         may be an "o" or you may encounter undefined behaviour with the
@@ -20,6 +20,8 @@ class LineParser:
         :param key_delimiters:              Delimiters between several keys
         :param section_name_surroundings:   Dictionary, e.g. {"[", "]"} means a
                                             section name is surrounded by [].
+                                            If None, {"[": "]"} is used as
+                                            default.
         :param section_override_delimiters: Delimiter for a section override.
                                             E.g. "." would mean that
                                             section.key is a possible key that
@@ -27,6 +29,8 @@ class LineParser:
                                             "section" despite of the current
                                             section.
         """
+        section_name_surroundings = section_name_surroundings or {"[": "]"}
+
         self.key_value_delimiters = key_value_delimiters
         self.comment_seperators = comment_seperators
         self.key_delimiters = key_delimiters

--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -125,7 +125,14 @@ def load_configuration(arg_list, log_printer):
     config = os.path.abspath(
         str(cli_sections["default"].get("config", user_config)))
 
-    coafile_sections = load_config_file(config, log_printer)
+    try:
+        save = bool(cli_sections["default"].get("save", "False"))
+    except ValueError:
+        # A file is deposited for the save parameter, means we want to save but
+        # to a specific file.
+        save = True
+
+    coafile_sections = load_config_file(config, log_printer, silent=save)
 
     sections = merge_section_dicts(default_sections, user_sections)
 


### PR DESCRIPTION
1. If a coafile was not found, say "Using default" instead of "Thus it
   will not be executed" (where the question arises "What is executed
   instead?").
2. If a user saves sections via command line and the coafile did not
   exist, don't say again "Thus it will not be used". The new inputted
   information _is_ used. So just trigger no warning.

Fixes #367 - I hope I fixed this issue correctly^^