### PR TITLE
StringProcessingTest: Use str(key) for assert msg

### DIFF
--- a/coalib/tests/parsing/StringProcessingTest.py
+++ b/coalib/tests/parsing/StringProcessingTest.py
@@ -77,7 +77,7 @@ class StringProcessingTest(unittest.TestCase):
         :param return: The error message.
         """
         args = [repr(x) for x in args]
-        kwargs = [repr(key) + '=' + repr(value)
+        kwargs = [str(key) + '=' + repr(value)
                   for key, value in kwargs.items()]
 
         return "Called {}({}).".format(func.__name__, ", ".join(args + kwargs))


### PR DESCRIPTION
Using repr(key) causes the output to wrap even the keywords in quotes.