### PR TITLE
log_exception(): Show traceback only on DEBUG

### DIFF
--- a/coalib/output/printers/LogPrinter.py
+++ b/coalib/output/printers/LogPrinter.py
@@ -67,16 +67,12 @@ class LogPrinter(Printer):
                                            timestamp=timestamp),
                                 **kwargs)
 
-    def log_exception(self,
+    def _log_exception(self,
                       message,
                       exception,
                       log_level=LOG_LEVEL.ERROR,
                       timestamp=None,
                       **kwargs):
-        if not isinstance(exception, BaseException):
-            raise TypeError("log_exception can only log derivatives of "
-                            "BaseException.")
-
         traceback_str = "\n".join(
             traceback.format_exception(type(exception),
                                        exception,
@@ -88,6 +84,39 @@ class LogPrinter(Printer):
                        _("Exception was:") + "\n" + traceback_str,
                        timestamp=timestamp),
             **kwargs)
+
+    def log_exception(self,
+                      message,
+                      exception,
+                      log_level=LOG_LEVEL.ERROR,
+                      timestamp=None,
+                      **kwargs):
+        """
+        If the log_level of the printer is greater than DEBUG, it prints
+        only the message. If it is DEBUG or lower, it shows the message
+        along with the traceback of the exception.
+
+        :param message:   The message to print.
+        :param exception: The exception to print.
+        :param log_level: The log_level of this message (not the traceback).
+        :param timestamp: The time at which this log occured. Defaults to
+                          the current time.
+        """
+        if self.log_level > LOG_LEVEL.DEBUG:
+            return self.log(log_level,
+                            message,
+                            timestamp=timestamp,
+                            **kwargs)
+        else:
+            if not isinstance(exception, BaseException):
+                raise TypeError("log_exception can only log derivatives of "
+                                "BaseException.")
+
+            return self._log_exception(message,
+                                       exception,
+                                       log_level=LOG_LEVEL.DEBUG,
+                                       timestamp=timestamp,
+                                       **kwargs)
 
     def log_message(self, log_message, **kwargs):
         if not isinstance(log_message, LogMessage):

--- a/coalib/tests/output/printers/LogPrinterTest.py
+++ b/coalib/tests/output/printers/LogPrinterTest.py
@@ -82,6 +82,18 @@ class LogPrinterTest(unittest.TestCase):
                     timestamp=self.timestamp,
                     end=""))
 
+        uut.log_level = LOG_LEVEL.DEBUG
+        logged = uut.log_exception(
+            "Something failed.",
+            NotImplementedError(Constants.COMPLEX_TEST_STRING),
+            timestamp=self.timestamp,
+            end="")
+        print(logged)
+        self.assertTrue(logged[0].startswith(
+            "[" + _("DEBUG") + "][" + self.timestamp.strftime("%X") +
+            "] Something failed.\n\n" + _("Exception was:") + "\n"))
+
+        uut.log_level = LOG_LEVEL.INFO
         logged = uut.log_exception(
             "Something failed.",
             NotImplementedError(Constants.COMPLEX_TEST_STRING),
@@ -89,10 +101,11 @@ class LogPrinterTest(unittest.TestCase):
             end="")
         self.assertTrue(logged[0].startswith(
             "[" + _("ERROR") + "][" + self.timestamp.strftime("%X") +
-            "] Something failed.\n\n" + _("Exception was:") + "\n"))
+            "] Something failed."))
 
     def test_raises(self):
         uut = LogPrinter()
+        uut.log_level = LOG_LEVEL.DEBUG
         self.assertRaises(TypeError, uut.log, 5)
         self.assertRaises(TypeError, uut.log_exception, "message", 5)
         self.assertRaises(TypeError, uut.log_message, 5)


### PR DESCRIPTION
log_exception() should show traceback only if LOG_VELEL is DEBUG
otherwise it may scare users.

Fixes https://github.com/coala-analyzer/coala/issues/807