### PR TITLE
log_exception(): Show traceback only on DEBUG

### DIFF
--- a/coalib/output/printers/LogPrinter.py
+++ b/coalib/output/printers/LogPrinter.py
@@ -34,38 +34,38 @@ class LogPrinter(Printer):
                                 datetime_string)
 
     def debug(self, *messages, delimiter=" ", timestamp=None, **kwargs):
-        return self.log_message(LogMessage(LOG_LEVEL.DEBUG,
-                                           *messages,
-                                           delimiter=delimiter,
-                                           timestamp=timestamp),
-                                **kwargs)
+        self.log_message(LogMessage(LOG_LEVEL.DEBUG,
+                                    *messages,
+                                    delimiter=delimiter,
+                                    timestamp=timestamp),
+                         **kwargs)
 
     def info(self, *messages, delimiter=" ", timestamp=None, **kwargs):
-        return self.log_message(LogMessage(LOG_LEVEL.INFO,
-                                           *messages,
-                                           delimiter=delimiter,
-                                           timestamp=timestamp),
-                                **kwargs)
+        self.log_message(LogMessage(LOG_LEVEL.INFO,
+                                    *messages,
+                                    delimiter=delimiter,
+                                    timestamp=timestamp),
+                         **kwargs)
 
     def warn(self, *messages, delimiter=" ", timestamp=None, **kwargs):
-        return self.log_message(LogMessage(LOG_LEVEL.WARNING,
-                                           *messages,
-                                           delimiter=delimiter,
-                                           timestamp=timestamp),
-                                **kwargs)
+        self.log_message(LogMessage(LOG_LEVEL.WARNING,
+                                    *messages,
+                                    delimiter=delimiter,
+                                    timestamp=timestamp),
+                         **kwargs)
 
     def err(self, *messages, delimiter=" ", timestamp=None, **kwargs):
-        return self.log_message(LogMessage(LOG_LEVEL.ERROR,
-                                           *messages,
-                                           delimiter=delimiter,
-                                           timestamp=timestamp),
-                                **kwargs)
+        self.log_message(LogMessage(LOG_LEVEL.ERROR,
+                                    *messages,
+                                    delimiter=delimiter,
+                                    timestamp=timestamp),
+                         **kwargs)
 
     def log(self, log_level, message, timestamp=None, **kwargs):
-        return self.log_message(LogMessage(log_level,
-                                           message,
-                                           timestamp=timestamp),
-                                **kwargs)
+        self.log_message(LogMessage(log_level,
+                                    message,
+                                    timestamp=timestamp),
+                         **kwargs)
 
     def log_exception(self,
                       message,
@@ -98,7 +98,7 @@ class LogPrinter(Printer):
                                        exception.__traceback__))
 
         self.log(log_level, message, timestamp=timestamp, **kwargs)
-        return self.log_message(
+        self.log_message(
             LogMessage(LOG_LEVEL.DEBUG,
                        _("Exception was:") + "\n" + traceback_str,
                        timestamp=timestamp),
@@ -111,7 +111,7 @@ class LogPrinter(Printer):
         if log_message.log_level < self.log_level:
             return
 
-        return self._print_log_message(
+        self._print_log_message(
             self._get_log_prefix(log_message.log_level, log_message.timestamp),
             log_message,
             **kwargs)
@@ -124,4 +124,4 @@ class LogPrinter(Printer):
         :param log_message: The LogMessage object to print.
         :param kwargs:      Any other keyword arguments.
         """
-        return self.print(prefix, log_message.message, **kwargs)
+        self.print(prefix, log_message.message, **kwargs)

--- a/coalib/output/printers/LogPrinter.py
+++ b/coalib/output/printers/LogPrinter.py
@@ -73,6 +73,21 @@ class LogPrinter(Printer):
                       log_level=LOG_LEVEL.ERROR,
                       timestamp=None,
                       **kwargs):
+        """
+        If the log_level of the printer is greater than DEBUG, it prints
+        only the message. If it is DEBUG or lower, it shows the message
+        along with the traceback of the exception.
+
+        :param message:   The message to print.
+        :param exception: The exception to print.
+        :param log_level: The log_level of this message (not used when
+                          logging the traceback. Tracebacks always have
+                          a level of DEBUG).
+        :param timestamp: The time at which this log occured. Defaults to
+                          the current time.
+        :param kwargs:    Keyword arguments to be passed when logging the
+                          message (not used when logging the traceback).
+        """
         if not isinstance(exception, BaseException):
             raise TypeError("log_exception can only log derivatives of "
                             "BaseException.")
@@ -82,9 +97,9 @@ class LogPrinter(Printer):
                                        exception,
                                        exception.__traceback__))
 
+        self.log(log_level, message, timestamp=timestamp, **kwargs)
         return self.log_message(
-            LogMessage(log_level,
-                       message + "\n\n" +
+            LogMessage(LOG_LEVEL.DEBUG,
                        _("Exception was:") + "\n" + traceback_str,
                        timestamp=timestamp),
             **kwargs)

--- a/coalib/tests/output/printers/LogPrinterTest.py
+++ b/coalib/tests/output/printers/LogPrinterTest.py
@@ -10,8 +10,16 @@ from coalib.misc.i18n import _
 
 
 class TestLogPrinter(LogPrinter):
+    def __init__(self, *args, **kwargs):
+        LogPrinter.__init__(self, *args, **kwargs)
+        self.printed = ''
+
     def _print(self, output, special_arg="test"):
+        self.printed += output + " " + special_arg + "\n"
         return output, special_arg
+
+    def clear(self):
+        self.printed = ""
 
 
 class LogPrinterTest(unittest.TestCase):
@@ -82,14 +90,29 @@ class LogPrinterTest(unittest.TestCase):
                     timestamp=self.timestamp,
                     end=""))
 
+        uut.log_level = LOG_LEVEL.DEBUG
+        uut.clear()
+        uut.log_exception(
+            "Something failed.",
+            NotImplementedError(Constants.COMPLEX_TEST_STRING),
+            timestamp=self.timestamp,
+            end="")
+        self.assertTrue(uut.printed.startswith(
+            "[" + _("ERROR") + "][" + self.timestamp.strftime("%X") +
+            "] Something failed. test\n" +
+            "[" + _("DEBUG") + "][" + self.timestamp.strftime("%X") +
+            "] " + _("Exception was:") + "\n"))
+
+        uut.log_level = LOG_LEVEL.INFO
+        uut.clear()
         logged = uut.log_exception(
             "Something failed.",
             NotImplementedError(Constants.COMPLEX_TEST_STRING),
             timestamp=self.timestamp,
             end="")
-        self.assertTrue(logged[0].startswith(
+        self.assertTrue(uut.printed.startswith(
             "[" + _("ERROR") + "][" + self.timestamp.strftime("%X") +
-            "] Something failed.\n\n" + _("Exception was:") + "\n"))
+            "] Something failed. test"))
 
     def test_raises(self):
         uut = LogPrinter()

--- a/coalib/tests/output/printers/LogPrinterTest.py
+++ b/coalib/tests/output/printers/LogPrinterTest.py
@@ -16,7 +16,6 @@ class TestLogPrinter(LogPrinter):
 
     def _print(self, output, special_arg="test"):
         self.printed += output + " " + special_arg + "\n"
-        return output, special_arg
 
     def clear(self):
         self.printed = ""
@@ -36,59 +35,79 @@ class LogPrinterTest(unittest.TestCase):
 
     def test_logging(self):
         uut = TestLogPrinter(timestamp_format="")
-        self.assertEqual(
-            (str(self.log_message), "special"),
-            uut.log_message(self.log_message, end="", special_arg="special"))
+        uut.log_message(self.log_message, end="", special_arg="special")
+        self.assertEqual(uut.printed, str(self.log_message) + " special\n")
 
         uut = TestLogPrinter(log_level=LOG_LEVEL.DEBUG)
+        uut.log_message(self.log_message, end="")
         self.assertEqual(
-            ("[" + _("ERROR") + "][" + self.timestamp.strftime("%X") + "] " +
-             Constants.COMPLEX_TEST_STRING, "test"),
-            uut.log_message(self.log_message, end=""))
-        self.assertEqual(
-            ("[" + _("ERROR") + "][" + self.timestamp.strftime("%X") + "] " +
-             Constants.COMPLEX_TEST_STRING, "test"),
-            uut.log(LOG_LEVEL.ERROR,
-                    Constants.COMPLEX_TEST_STRING,
-                    timestamp=self.timestamp,
-                    end=""))
+            uut.printed,
+            "[" + _("ERROR") + "][" + self.timestamp.strftime("%X") + "] " +
+            Constants.COMPLEX_TEST_STRING + " test\n")
 
+        uut.clear()
+        uut.log(LOG_LEVEL.ERROR,
+                Constants.COMPLEX_TEST_STRING,
+                timestamp=self.timestamp,
+                end="")
         self.assertEqual(
-            ("[" + _("DEBUG") + "][" + self.timestamp.strftime("%X") + "] " +
-             Constants.COMPLEX_TEST_STRING + " d", "test"),
-            uut.debug(Constants.COMPLEX_TEST_STRING,
-                      "d",
-                      timestamp=self.timestamp,
-                      end=""))
+            uut.printed,
+            "[" + _("ERROR") + "][" + self.timestamp.strftime("%X") + "] " +
+            Constants.COMPLEX_TEST_STRING + " test\n")
+
+        uut.clear()
+        uut.debug(Constants.COMPLEX_TEST_STRING,
+                  "d",
+                  timestamp=self.timestamp,
+                  end="")
+        self.assertEqual(
+            uut.printed,
+            "[" + _("DEBUG") + "][" + self.timestamp.strftime("%X") + "] " +
+            Constants.COMPLEX_TEST_STRING + " d test\n")
+
+        uut.clear()
         uut.log_level = LOG_LEVEL.INFO
-        self.assertEqual(None, uut.debug(Constants.COMPLEX_TEST_STRING,
-                                         timestamp=self.timestamp,
-                                         end=""))
+        uut.debug(Constants.COMPLEX_TEST_STRING,
+                  timestamp=self.timestamp,
+                  end="")
+        self.assertEqual(uut.printed, "")
+
+        uut.clear()
+        uut.info(Constants.COMPLEX_TEST_STRING,
+                 "d",
+                 timestamp=self.timestamp,
+                 end="")
         self.assertEqual(
-            ("[" + _("INFO") + "][" + self.timestamp.strftime("%X") + "] " +
-             Constants.COMPLEX_TEST_STRING + " d", "test"),
-            uut.info(Constants.COMPLEX_TEST_STRING,
-                      "d",
-                      timestamp=self.timestamp,
-                      end=""))
+            uut.printed,
+            "[" + _("INFO") + "][" + self.timestamp.strftime("%X") + "] " +
+            Constants.COMPLEX_TEST_STRING + " d test\n")
+
         uut.log_level = LOG_LEVEL.WARNING
-        self.assertEqual(None, uut.debug(Constants.COMPLEX_TEST_STRING,
-                                         timestamp=self.timestamp,
-                                         end=""))
+        uut.clear()
+        uut.debug(Constants.COMPLEX_TEST_STRING,
+                  timestamp=self.timestamp,
+                  end="")
+        self.assertEqual(uut.printed, "")
+
+        uut.clear()
+        uut.warn(Constants.COMPLEX_TEST_STRING,
+                 "d",
+                 timestamp=self.timestamp,
+                 end="")
         self.assertEqual(
-            ("[" + _("WARNING") + "][" + self.timestamp.strftime("%X") + "] " +
-             Constants.COMPLEX_TEST_STRING + " d", "test"),
-            uut.warn(Constants.COMPLEX_TEST_STRING,
-                     "d",
-                     timestamp=self.timestamp,
-                     end=""))
+            uut.printed,
+            "[" + _("WARNING") + "][" + self.timestamp.strftime("%X") + "] " +
+            Constants.COMPLEX_TEST_STRING + " d test\n")
+
+        uut.clear()
+        uut.err(Constants.COMPLEX_TEST_STRING,
+                "d",
+                timestamp=self.timestamp,
+                end="")
         self.assertEqual(
-            ("[" + _("ERROR") + "][" + self.timestamp.strftime("%X") + "] " +
-             Constants.COMPLEX_TEST_STRING + " d", "test"),
-            uut.err(Constants.COMPLEX_TEST_STRING,
-                    "d",
-                    timestamp=self.timestamp,
-                    end=""))
+            uut.printed,
+            "[" + _("ERROR") + "][" + self.timestamp.strftime("%X") + "] " +
+            Constants.COMPLEX_TEST_STRING + " d test\n")
 
         uut.log_level = LOG_LEVEL.DEBUG
         uut.clear()


### PR DESCRIPTION
log_exception() should show traceback only if LOG_LEVEL is DEBUG
otherwise it may scare users.

Fixes https://github.com/coala-analyzer/coala/issues/807