### PR TITLE
ClangCloneDetectionBear: Reduce threshold

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,12 @@
 
 This release features the following feature changes:
 
+ * `--find-config` flag: Searches for .coafile in all parent directories.
+ * Add code clone detection bears and algorithms using CMCD approach.
+ * Console color gets properly disabled now for non-supporting platforms (like
+   Windows).
+ * coala results can be outputted to JSON format using the `coala-json`
+   command.
  * Automatically add needed flags to open a new process for some editors.
  * Save backup before applying actions to files.
  * Return nonzero when erroring or yielding results.
@@ -11,7 +17,6 @@ This release features the following feature changes:
  * Manual written documentation is now hosted at http://coala.rtfd.org/.
  * Changed logging API in Bears (now: debug/warn/err).
  * clang python bindings were added to the bearlib.
- * ClangCodeCloneDetection bear was added.
  * Exitcodes were organized and documented.
    (http://coala.readthedocs.org/en/latest/Users/Exit_Codes/)
  * Handling of EOF/Keyboard Interrupt was improved.

--- a/bears/codeclone_detection/ClangCloneDetectionBear.py
+++ b/bears/codeclone_detection/ClangCloneDetectionBear.py
@@ -9,7 +9,7 @@ from bears.codeclone_detection.ClangFunctionDifferenceBear import (
 class ClangCloneDetectionBear(GlobalBear):
     def run(self,
             dependency_results: dict,
-            max_clone_difference: float=0.308):
+            max_clone_difference: float=0.185):
         '''
         Checks the given code for similar functions that are probably
         redundant.

--- a/bears/tests/codeclone_detection/ClangCloneDetectionBearTest.py
+++ b/bears/tests/codeclone_detection/ClangCloneDetectionBearTest.py
@@ -21,6 +21,7 @@ class ClangCloneDetectionBearTest(unittest.TestCase):
             "clone_detection_samples"))
         self.section = Section("default")
         self.section.append(Setting("files", "", origin=self.base_test_path))
+        self.section.append(Setting("max_clone_difference", "0.308"))
         self.clone_files = [os.listdir(os.path.join(self.base_test_path,
                                                     "clones"))]
 

--- a/coalib/coala.py
+++ b/coalib/coala.py
@@ -64,7 +64,7 @@ def main():
 
         if yielded_results:
             exitcode = 1
-    except Exception as exception:  # pylint: disable=broad-except
+    except BaseException as exception:  # pylint: disable=broad-except
         exitcode = exitcode or get_exitcode(exception, log_printer)
 
     return exitcode

--- a/coalib/coala_ci.py
+++ b/coalib/coala_ci.py
@@ -43,7 +43,7 @@ def main():
 
         if yielded_results:
             exitcode = 1
-    except Exception as exception:  # pylint: disable=broad-except
+    except BaseException as exception:  # pylint: disable=broad-except
         exitcode = exitcode or get_exitcode(exception, log_printer)
 
     return exitcode

--- a/coalib/coala_json.py
+++ b/coalib/coala_json.py
@@ -60,7 +60,7 @@ def main():
 
         if yielded_results:
             exitcode = 1
-    except Exception as exception:  # pylint: disable=broad-except
+    except BaseException as exception:  # pylint: disable=broad-except
         exitcode = exitcode or get_exitcode(exception, log_printer)
 
     retval = {"logs": log_printer.logs, "results": results}

--- a/coalib/misc/Exceptions.py
+++ b/coalib/misc/Exceptions.py
@@ -21,7 +21,7 @@ def get_exitcode(exception, log_printer=None):
         print(_("Found EOF. Exiting gracefully."))
     elif isinstance(exception, SystemExit):
         exitcode = exception.code
-    elif isinstance(exception, Exception):
+    elif isinstance(exception, BaseException):
         log_printer.log_exception(Constants.CRASH_MESSAGE, exception)
         exitcode = 255
 

--- a/coalib/output/dbus/DbusDocument.py
+++ b/coalib/output/dbus/DbusDocument.py
@@ -138,7 +138,7 @@ class DbusDocument(dbus.service.Object):
 
             if yielded_results:
                 exitcode = 1
-        except Exception as exception:  # pylint: disable=broad-except
+        except BaseException as exception:  # pylint: disable=broad-except
             exitcode = exitcode or get_exitcode(exception, log_printer)
 
         logs = [log.to_string_dict() for log in log_printer.logs]


### PR DESCRIPTION
My evaluations have come up with 0.185 as a very good threshold value
that yields almost no false positives which is more important than a few
clones not found. If someone whishes to do a more elaborate examination
of clones he is hereby invited to raise the threshold manually.