### PR TITLE
ConsoleInteraction: Color print fix

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -200,7 +200,7 @@ def print_results(log_printer,
                   result_list,
                   file_dict,
                   file_diff_dict,
-                  color=True,
+                  color=None,
                   pre_padding=3):
     """
     Print all the results in a section.
@@ -213,7 +213,7 @@ def print_results(log_printer,
     :param file_diff_dict: A dictionary that contains filenames as keys and
                            diff objects as values.
     :param color:          Boolean variable to print the results in color or
-                           not.
+                           not. If None, use colors when supported.
     :param pre_padding:    No of lines of file to print before the result line.
                            Default value is 3.
     """

--- a/coalib/output/printers/ColorPrinter.py
+++ b/coalib/output/printers/ColorPrinter.py
@@ -19,19 +19,23 @@ class ColorPrinter(Printer):
         class handles this for you.
     """
 
-    def __init__(self, print_colored=True):
+    def __init__(self, print_colored=None):
         """
         Creates a new ColorPrinter.
 
         :param print_colored: Can be set to False to use uncolored printing
-                              only.
+                              only. If None print colored only when supported.
         """
         Printer.__init__(self)
 
         self.print_colored = print_colored
 
     def _print(self, output, **kwargs):
-        if kwargs.get("color") is None or not self.print_colored:
+        if (
+                kwargs.get("color") is None or
+                (self.print_colored is None and
+                 not self._are_colors_supported())
+                or self.print_colored == False):
             return self._print_uncolored(output, **kwargs)
 
         try:
@@ -57,3 +61,20 @@ class ColorPrinter(Printer):
         :param kwargs: Arbitrary additional keyword arguments you might need.
         """
         raise NotImplementedError
+
+    @staticmethod
+    def _are_colors_supported():
+        """
+        Returns whether color printing is currently supported or not.
+
+        Override this function to restrict default output behaviour with
+        colors.
+
+        By default color printing is supported every time.
+
+        Note: Don't invoke this function statically since it is intended that
+        color support may also change during Printer life-cycle.
+
+        :return: True if color printing is supported, False if not.
+        """
+        return True

--- a/coalib/output/printers/ConsolePrinter.py
+++ b/coalib/output/printers/ConsolePrinter.py
@@ -9,8 +9,17 @@ class ConsolePrinter(ColorPrinter):
 
     Note that pickling will not pickle the output member.
     """
-    def __init__(self,
-                 print_colored=platform.system() in ("Linux",)):
+
+    def __init__(self, print_colored=None):
+        """
+        Instantiates a new ConsolePrinter.
+
+        :param log_level:        The log-level that will be used for logging.
+        :param timestamp_format: The timestamp format used for logging the
+                                 time.
+        :param print_colored:    Whether to print with colors or not. If None,
+                                 print in colors if supported.
+        """
         ColorPrinter.__init__(self, print_colored)
 
     def _print_uncolored(self, output, **kwargs):
@@ -41,3 +50,7 @@ class ConsolePrinter(ColorPrinter):
             raise ValueError("Invalid color value.")
 
         print('\033[' + color_code + 'm' + output + '\033[0m', end="")
+
+    @staticmethod
+    def _are_colors_supported():
+        return platform.system() in ("Linux",)

--- a/coalib/tests/output/printers/ColorPrinterTest.py
+++ b/coalib/tests/output/printers/ColorPrinterTest.py
@@ -6,8 +6,12 @@ import unittest
 
 
 class TestColorPrinter(ColorPrinter):
+    def __init__(self, *args):
+        ColorPrinter.__init__(self, *args)
+        self.string = ""
+
     def _print_colored(self, output, color=None, **kwargs):
-        pass
+        self.string += "HIT"
 
     def _print_uncolored(self, output, **kwargs):
         raise NotImplementedError
@@ -22,15 +26,22 @@ class ColorPrinterTest(unittest.TestCase):
                           "test",
                           color='green')
 
+    def test_force_colored(self):
+        uut = TestColorPrinter(True)
+        uut.print("test", color="red")
+        self.assertEqual(uut.string, "HIT")
+
     def test_force_uncolored(self):
         uut = TestColorPrinter(False)
         with self.assertRaises(NotImplementedError):
             uut.print("test", color="green")
 
-        uut = TestColorPrinter()
-        # Doesn't raise
-        uut.print("test", color="green")
-
+    def test_system_supported(self):
+        uut = TestColorPrinter(None)
+        # This print should not throw because by default color is every time
+        # supported, so it will print colored.
+        uut.print("test", color="blue")
+        self.assertEqual(uut.string, "HIT")
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
The color setting overrides the ConsolePrinter default. If now
providing None, the desired default is used.

This really fixes the color-on-windows issue^^