### PR TITLE
Makman2/generate-repr-autoprop

### DIFF
--- a/coalib/misc/Decorators.py
+++ b/coalib/misc/Decorators.py
@@ -151,10 +151,12 @@ def generate_repr(*members):
             # Need to fetch member variables every time since they are unknown
             # until class instantation.
             members_to_print = (
-                (member, repr) for member in
-                sorted(filter(lambda mem: not mem.startswith("_"),
-                              self.__dict__),
-                       key=str.lower))
-            return _construct_repr_string(self, members_to_print)
+                filter(lambda member: not member.startswith("_"),
+                       self.__dict__))
+
+            member_repr_list = ((member, repr) for member in
+                sorted(members_to_print, key=str.lower))
+
+            return _construct_repr_string(self, member_repr_list)
 
     return decorator

--- a/coalib/misc/Decorators.py
+++ b/coalib/misc/Decorators.py
@@ -97,10 +97,9 @@ def generate_repr(*members):
 
     :param members:         An iterable of member names to include into the
                             representation-string. Providing no members yields
-                            to inclusion of all member variables in
-                            alphabetical order (even that ones are included
-                            that change after instantation, but no properties
-                            or other attributes starting with an underscore).
+                            to inclusion of all member variables and properties
+                            in alphabetical order (except if they start with an
+                            underscore).
 
                             To control the representation of each member, you
                             can also pass a tuple where the first element
@@ -150,9 +149,16 @@ def generate_repr(*members):
         def __repr__(self):
             # Need to fetch member variables every time since they are unknown
             # until class instantation.
-            members_to_print = (
+            members_to_print = set(
                 filter(lambda member: not member.startswith("_"),
                        self.__dict__))
+            # Also fetch properties.
+            self_type_dict = type(self).__dict__
+            members_to_print |= set(
+                filter(lambda member: isinstance(self_type_dict[member],
+                                                 property)
+                                      and not member.startswith("_"),
+                       self_type_dict))
 
             member_repr_list = ((member, repr) for member in
                 sorted(members_to_print, key=str.lower))

--- a/coalib/tests/misc/DecoratorsTest.py
+++ b/coalib/tests/misc/DecoratorsTest.py
@@ -55,6 +55,10 @@ class GenerateReprTest(unittest.TestCase):
                 return self.one * "getter()"
 
             @property
+            def _private_prop(self):
+                return self.one
+
+            @property
             def defaulted_getter(self, a=3, b=2):
                 return a * b * self.one
 
@@ -180,21 +184,24 @@ class GenerateReprTest(unittest.TestCase):
 
         self.assertRegex(repr(x),
                          "<X object\\(A=2, B='A string', ComplexMember=\\[3, "
-                         "2, 1\\], one=1, Q=0\\.5\\) at 0x[0-9a-fA-F]+>")
+                         "2, 1\\], defaulted_getter=6, getter='getter\\(\\)', "
+                         "one=1, Q=0\\.5\\) at 0x[0-9a-fA-F]+>")
 
         # Insert member after instantation.
         x.Z = 17
         self.assertRegex(repr(x),
                          "<X object\\(A=2, B='A string', ComplexMember=\\[3, "
-                         "2, 1\\], one=1, Q=0\\.5, Z=17\\) at 0x[0-9a-fA-F]+>")
+                         "2, 1\\], defaulted_getter=6, getter='getter\\(\\)', "
+                         "one=1, Q=0\\.5, Z=17\\) at 0x[0-9a-fA-F]+>")
 
         # Test alphabetical order a bit more.
         x.Ba = 4
         x.g_mem = 0
         self.assertRegex(repr(x),
                          "<X object\\(A=2, B='A string', Ba=4, "
-                         "ComplexMember=\\[3, 2, 1\\], g_mem=0, one=1, "
-                         "Q=0\\.5, Z=17\\) at 0x[0-9a-fA-F]+>")
+                         "ComplexMember=\\[3, 2, 1\\], defaulted_getter=6, "
+                         "g_mem=0, getter='getter\\(\\)', one=1, Q=0\\.5, "
+                         "Z=17\\) at 0x[0-9a-fA-F]+>")
 
     def test_duplicate_member(self):
         X = generate_repr("A", "A")(self.define_class())


### PR DESCRIPTION
`@generate_repr` includes in parameterless mode now non-private properties.