### PR TITLE
Result: Use uuid to generate id

### DIFF
--- a/coalib/results/Result.py
+++ b/coalib/results/Result.py
@@ -1,4 +1,5 @@
 from functools import total_ordering
+import uuid
 
 from coalib.misc.Decorators import generate_repr
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
@@ -60,11 +61,7 @@ class Result:
         self.line_nr = line_nr
         self.severity = severity
         self.diffs = diffs
-        # Convert debug message to string: some bears pack lists in there which
-        # is very useful when exporting the stuff to JSON and further working
-        # with the debug data. However, hash can't handle that.
-        self.id = hash(
-            (origin, message, str(debug_msg), file, line_nr, severity))
+        self.id = uuid.uuid4().int
 
     def __eq__(self, other):
         # ID isn't relevant for content equality!


### PR DESCRIPTION
This has a higher chance of being unique since it's made for having a
high chance of uniqueness.

We use uuid4 because it generates a random UUID, other generators may
invade the users privacy by hashing in platform dependent data and
privacy is important :).