### PR TITLE
ConsoleInteraction: Move out result context printing

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -222,7 +222,7 @@ def print_affected_lines(console_printer, pre_padding, file_dict, result):
     console_printer.print("\n\n" + result.file, color=FILE_NAME_COLOR)
 
     if result.line_nr is not None:
-        if len(file_dict[result.file]) < result.line_nr - 1:
+        if len(file_dict[result.file]) < result.line_nr:
             console_printer.print(format_lines(lines=STR_LINE_DOESNT_EXIST))
         else:
             print_lines(console_printer,

--- a/coalib/tests/output/ConsoleInteractionTest.py
+++ b/coalib/tests/output/ConsoleInteractionTest.py
@@ -363,13 +363,28 @@ file
             print_results(
                 self.log_printer,
                 Section(""),
-                [Result("t", "msg", "file", line_nr=5)],
-                {"file": []},
+                [Result("t", "msg", "file", line_nr=5),
+                 Result("t", "msg", "file", line_nr=6)],
+                {"file": ["line " + str(i+1) for i in range(5)]},
                 {},
                 color=False)
-            self.assertEqual("""\n\nfile\n|    | {}\n|    | [{}] t:
-|    | msg\n""".format(STR_LINE_DOESNT_EXIST,
-                            RESULT_SEVERITY.__str__(RESULT_SEVERITY.NORMAL)),
+            # "NORMAL" but translated to test system language
+            NORMAL = RESULT_SEVERITY.__str__(RESULT_SEVERITY.NORMAL)
+            self.assertEqual("\n\n"
+                             "file\n"
+                             "| ...| \n"
+                             "|   2| line 2\n"
+                             "|   3| line 3\n"
+                             "|   4| line 4\n"
+                             "|   5| line 5\n"
+                             "|    | [{sev}] t:\n"
+                             "|    | msg\n"
+                             "\n\n"
+                             "file\n"
+                             "|    | {}\n"
+                             "|    | [{sev}] t:\n"
+                             "|    | msg\n".format(STR_LINE_DOESNT_EXIST,
+                                                   sev=NORMAL),
                              stdout.getvalue())
 
     def test_print_results_without_line(self):


### PR DESCRIPTION
This simplifies the result printing by far because it splits out the
context printing of the result and gets rid of the state machine.

As a result functionality changes a bit, gets a bit simpler, because
we're getting rid of the complicated state machine with current file and
current line: the full context (file and the three lines before) is
printed for each result, even if it has the same file as the last one.
If no file but a line is given, it will simply be printed project wide
(way simpler: no file -> project wide. Ignore line.)

This is a preparation for getting the new results in. Plus a
simplification and code removal which is good too :).