### PR TITLE
Revert "Use language-check 0.7.2 explicitly"

### DIFF
--- a/.misc/appveyor.yml
+++ b/.misc/appveyor.yml
@@ -41,7 +41,7 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  - "%CMD_IN_ENV% pip -q install coverage pylint setuptools munkres3 language-check==0.7.2 PyPrint"
+  - "%CMD_IN_ENV% pip -q install coverage pylint setuptools munkres3 language-check PyPrint"
   - "%CMD_IN_ENV% pip -q install --upgrade astroid"
 
   - "nuget install Gettext.Tools -Version 0.19.4"


### PR DESCRIPTION
This reverts commit 3d9a782f064109fea5a6a38e605fb3ae97f40fb4.

The appveyor related issue has been fixed and released upstream, see
https://github.com/myint/language-check/issues/19