### PR TITLE
Bear: Fail on inconvertible value

### DIFF
--- a/bears/codeclone_detection/ClangFunctionDifferenceBear.py
+++ b/bears/codeclone_detection/ClangFunctionDifferenceBear.py
@@ -125,11 +125,6 @@ class ClangFunctionDifferenceBear(GlobalBear):
                                     function pairs will be reduced using an
                                     exponential approach.
         '''
-        if not isinstance(counting_conditions, dict):
-            self.err("The counting_conditions setting is invalid. Code clone "
-                     "detection cannot run.")
-            return
-
         self.debug("Using the following counting conditions:")
         for key, val in counting_conditions.items():
             self.debug(" *", key.__name__, "(weighting: {})".format(val))

--- a/bears/tests/codeclone_detection/ClangCloneDetectionBearTest.py
+++ b/bears/tests/codeclone_detection/ClangCloneDetectionBearTest.py
@@ -41,12 +41,6 @@ class ClangCloneDetectionBearTest(unittest.TestCase):
         self.check_clone_detection_bear(self.clone_files,
                                         lambda results, msg: True)
 
-    def test_invalid_conditions(self):
-        self.section.append(Setting("counting_conditions", "bullshit"))
-
-        self.uut = ClangFunctionDifferenceBear({}, self.section, Queue())
-        self.assertEqual(list(self.uut.run_bear_from_section([], {})), [])
-
     def test_non_clones(self):
         self.non_clone_files = [
             os.path.join(self.base_test_path, "non_clones", elem)

--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -62,8 +62,13 @@ class Bear(Printer, LogPrinter):
         raise NotImplementedError
 
     def run_bear_from_section(self, args, kwargs):
-        kwargs.update(
-            self.get_metadata().create_params_from_section(self.section))
+        try:
+            kwargs.update(
+                self.get_metadata().create_params_from_section(self.section))
+        except ValueError as err:
+            self.warn(_("The bear {} cannot be executed.").format(
+                self.__class__.__name__), str(err))
+            return []
 
         return self.run(*args, **kwargs)
 

--- a/coalib/settings/FunctionMetadata.py
+++ b/coalib/settings/FunctionMetadata.py
@@ -1,10 +1,8 @@
 from inspect import ismethod, getfullargspec
 from collections import OrderedDict
 from copy import copy
-from pyprint.ConsolePrinter import ConsolePrinter
 
 from coalib.settings.DocumentationComment import DocumentationComment
-from coalib.output.printers.LogPrinter import LogPrinter
 from coalib.misc.i18n import _
 
 
@@ -77,9 +75,7 @@ class FunctionMetadata:
         """
         return self._filter_out_omitted(self._optional_params)
 
-    def create_params_from_section(self,
-                                   section,
-                                   log_printer=LogPrinter(ConsolePrinter())):
+    def create_params_from_section(self, section):
         """
         Create a params dictionary for this function that holds all values the
         function needs plus optional ones that are available.
@@ -99,31 +95,25 @@ class FunctionMetadata:
 
         for param in self.non_optional_params:
             dummy, annotation = self.non_optional_params[param]
-            params[param] = self._get_param(param,
-                                            section,
-                                            annotation,
-                                            log_printer)
+            params[param] = self._get_param(param, section, annotation)
 
         for param in self.optional_params:
             if param in section:
                 dummy, annotation, dummy = self.optional_params[param]
-                params[param] = self._get_param(param,
-                                                section,
-                                                annotation,
-                                                log_printer)
+                params[param] = self._get_param(param, section, annotation)
 
         return params
 
     @staticmethod
-    def _get_param(param, section, annotation, log_printer):
+    def _get_param(param, section, annotation):
         if annotation is None:
             annotation = lambda x: x
+
         try:
             return annotation(section[param])
         except:
-            log_printer.warn(_("Unable to convert {param} to the desired "
-                               "data type.").format(param=param))
-            return section[param]
+            raise ValueError("Unable to convert parameter {} into type "
+                             "{}.".format(repr(param), annotation))
 
     @classmethod
     def from_function(cls, func, omit=frozenset()):

--- a/coalib/tests/bearlib/spacing/SpacingHelperTest.py
+++ b/coalib/tests/bearlib/spacing/SpacingHelperTest.py
@@ -3,7 +3,6 @@ sys.path.insert(0, ".")
 import unittest
 from coalib.settings.Section import Section
 from coalib.bearlib.spacing.SpacingHelper import SpacingHelper
-from coalib.settings.Setting import Setting
 
 
 class SpacingHelperTest(unittest.TestCase):
@@ -21,11 +20,6 @@ class SpacingHelperTest(unittest.TestCase):
 
         self.assertEqual(self.uut.tab_width,
                          self.uut.from_section(section).tab_width)
-
-        section.append(Setting("tab_width", "invalid"))
-        # Setting won't be converted since it's not possible, SpacingHelper
-        # will then complain with TypeError
-        self.assertRaises(TypeError, self.uut.from_section, section)
 
         # This is assumed in some tests. If you want to change this value, be
         # sure to change the tests too

--- a/coalib/tests/settings/FunctionMetadataTest.py
+++ b/coalib/tests/settings/FunctionMetadataTest.py
@@ -17,6 +17,9 @@ class TestClass:
         :return:       ret
         """
 
+    def good_function(self, a_param: int):
+        pass
+
     def bad_function(self, bad_param: "no function"):
         pass
 
@@ -67,12 +70,26 @@ class FunctionMetadataTest(unittest.TestCase):
                            int,
                            6)})
 
-    def test_create_params_from_section(self):
+    def test_create_params_from_section_invalid(self):
         section = Section("name")
         section.append(Setting("bad_param", "value"))
         uut = FunctionMetadata.from_function(TestClass(5, 5).bad_function)
+
+        with self.assertRaises(ValueError):
+            uut.create_params_from_section(section)
+
+    def test_create_params_from_section_valid(self):
+        section = Section("name")
+        section.append(Setting("a_param", "value"))
+        uut = FunctionMetadata.from_function(TestClass(5, 5).good_function)
+
+        with self.assertRaises(ValueError):
+            uut.create_params_from_section(section)
+
+        section.append(Setting("a_param", "5"))
         params = uut.create_params_from_section(section)
-        self.assertIsInstance(params["bad_param"], Setting)
+        self.assertEqual(params['a_param'], 5)
+
 
     def check_function_metadata_data_set(self,
                                          metadata,


### PR DESCRIPTION
We don't want to execute a bear if its value isn't in a type he desires.

Fixes https://github.com/coala-analyzer/coala/issues/800