### PR TITLE
Constants: Pass on failure of tags dir creation

### DIFF
--- a/coalib/misc/Constants.py
+++ b/coalib/misc/Constants.py
@@ -73,5 +73,7 @@ class Constants:
         USER_DIR = os.path.join(os.path.expanduser("~"), ".local", "coala")
 
     TAGS_DIR = os.path.join(USER_DIR, "tags")
-    if not os.path.exists(TAGS_DIR):  # pragma: no cover
+    try:
         os.makedirs(TAGS_DIR)
+    except:  # pragma: no cover
+        pass


### PR DESCRIPTION
In certain environments access to this directory might not be given.
coala should not fail to run because of this.