### PR TITLE
Use fail_acquire_settings in coala_main.py. Fixes #1066

### DIFF
--- a/coalib/coala_main.py
+++ b/coalib/coala_main.py
@@ -9,6 +9,7 @@ from coalib.settings.ConfigurationGathering import gather_configuration
 from coalib.misc.Exceptions import get_exitcode
 from coalib.bears.BEAR_KIND import BEAR_KIND
 from coalib.collecting.Collectors import collect_bears
+from coalib.output.Interactions import fail_acquire_settings
 from coalib.output.Tagging import tag_results, delete_tagged_results
 
 
@@ -17,7 +18,7 @@ do_nothing = lambda *args: True
 
 def run_coala(log_printer=None,
               print_results=do_nothing,
-              acquire_settings=do_nothing,
+              acquire_settings=fail_acquire_settings,
               print_section_beginning=do_nothing,
               nothing_done=do_nothing,
               show_bears=do_nothing):

--- a/coalib/tests/coalaTest.py
+++ b/coalib/tests/coalaTest.py
@@ -78,6 +78,12 @@ class coalaTest(unittest.TestCase):
         execute_coala_ci(("-S", "dtag=test_tag", "-c", self.coafile))
         self.assertFalse(os.path.exists(tag_path))
 
+    def test_fail_acquire_settings(self):
+        """It raises an AssertionError when required settings are missing."""
+        retval, output = execute_coala_ci((
+            "-b", 'SpaceConsistencyBear', '-c', '/dev/null'))
+        self.assertIn("During execution, we found that some", output)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
This is a fix for #1066. I've added a test case that verifies the original error is gone. What do you think about having fixtures as actual files in the tests folder? I have mixed feelings, as normal test cases shouldn't require the creation of extra files.