### PR TITLE
coala: unreliable crash

### DIFF
--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -256,3 +256,5 @@ class Diff:
 
     def __eq__(self, other):
         return self._changes == other._changes
+#dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+        return True


### PR DESCRIPTION
I noticed this by accident, might be worth investigating.

(not always) reproducible crash:

* run coala with `./coala`
* on the first result shown choose the option to manually edit (crashed for me on kwrite and vim, not kate though)
* delete line 259
* save and close
* choose no further options

```python
fabian@localghost:~/Projekte/coala> ./coala
Executing section PythonCheck...

/home/fabian/Projekte/coala/coalib/results/ResultFilter.py                                                                                                                                                                                         
|  68| dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
|    | [NORMAL] LineLengthBear:
|    | Line is longer than allowed. (99 > 80)
|    | The following actions are applicable to this result:
|    |  0: Apply no further actions.
|    |  1: Open the affected file(s) in an editor.
|    | Please enter the number of the action you want to execute. 1
|    | Please enter a value for the parameter 'editor' (The editor to open the file with.): kwrite
|    | The action was executed successfully.
|    | The following actions are applicable to this result:
|    |  0: Apply no further actions.
|    |  1: Open the affected file(s) in an editor.
|    | Please enter the number of the action you want to execute. 0

/home/fabian/Projekte/coala/coalib/results/ResultFilter.py                                                                                                                                                                                         
|  69|     return True
|    | [NORMAL] SpaceConsistencyBear:
|    | Line contains following spacing inconsistencies:
|    | - No newline at EOF.
|    | - Trailing whitespaces.
[ERROR][22:17:33] An unknown error occurred. This is a bug. We are sorry for the inconvenience. Please contact the developers for assistance. During execution of coala an exception was raised. This should never happen. When asked for, the following information may help investigating:
```

yep... there is nothing that might help investigating...
@sils1297: any ideas?
