### PR TITLE
Migrate mdast to remark

### DIFF
--- a/.misc/appveyor.yml
+++ b/.misc/appveyor.yml
@@ -33,7 +33,9 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  - "%CMD_IN_ENV% pip -q install coverage pylint setuptools munkres3 language-check PyPrint restructuredtext_lint autoflake autopep8 eradicate cpplint isort"
+  - "%CMD_IN_ENV% pip -q install coverage pylint setuptools munkres3 proselint"
+  - "%CMD_IN_ENV% pip -q install language-check PyPrint restructuredtext_lint"
+  - "%CMD_IN_ENV% pip -q install autoflake autopep8 eradicate cpplint isort"
   - "%CMD_IN_ENV% pip -q install --upgrade astroid"
 
 build: false  # Not a C# project, build stuff at the test step instead.

--- a/.misc/deps.sh
+++ b/.misc/deps.sh
@@ -27,7 +27,7 @@ deps_python_gi="glib2.0-dev gobject-introspection libgirepository1.0-dev python3
 sudo apt-get -qq install $deps $deps_python_gi $deps_python_dbus
 
 # NPM commands
-npm install -g jshint alex mdast dockerfile_lint csslint coffeelint
+npm install -g jshint alex remark dockerfile_lint csslint coffeelint
 
 for dep_version in "${dep_versions[@]}" ; do
   pyenv install -ks $dep_version

--- a/bears/natural_language/MarkdownBear.py
+++ b/bears/natural_language/MarkdownBear.py
@@ -2,7 +2,7 @@ from coalib.bearlib.abstractions.CorrectionBasedBear import CorrectionBasedBear
 
 
 class MarkdownBear(CorrectionBasedBear):
-    BINARY = 'mdast'
+    BINARY = 'remark'
     RESULT_MESSAGE = "The text does not comply to the set style."
 
     def run(self, filename, file):

--- a/bears/tests/natural_language/MarkdownBearTest.py
+++ b/bears/tests/natural_language/MarkdownBearTest.py
@@ -20,7 +20,7 @@ def skip_test():
                          stderr=subprocess.PIPE)
         return False
     except OSError:
-        return "mdast is not installed."
+        return "remark is not installed."
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`mdast` was officially renamed to `remark`.