### PR TITLE
CorrectionBasedBearTest: Make coverage standalone

### DIFF
--- a/coalib/tests/bearlib/abstractions/CorrectionBasedBearTest.py
+++ b/coalib/tests/bearlib/abstractions/CorrectionBasedBearTest.py
@@ -36,6 +36,13 @@ class CorrectionBasedBearTest(LocalBearTestHelper):
         self.assertEqual(IndentBear.check_prerequisites(),
                          "'fdgskjfdgjdfgnlfdslk' is not installed.")
 
+        # "echo" is existent on nearly all platforms.
+        IndentBear.BINARY = "echo"
+        self.assertTrue(IndentBear.check_prerequisites())
+
+        del IndentBear.BINARY
+        self.assertTrue(IndentBear.check_prerequisites())
+
         IndentBear.BINARY = old_binary
 
 


### PR DESCRIPTION
`check_prerequisites` is now completely covered by the
`CorrectionBasedBearTest` itself.