### PR TITLE
Processing: Treat failing actions as unprocessed

### DIFF
--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -147,6 +147,7 @@ def autoapply_actions(results,
                 repr(action.get_metadata().name),
                 repr(result.origin)))
         except Exception as ex:
+            not_processed_results.append(result)
             log_printer.log_exception(
                 "Failed to execute action {}.".format(
                     repr(action.get_metadata().name)),

--- a/coalib/tests/processes/ProcessingTest.py
+++ b/coalib/tests/processes/ProcessingTest.py
@@ -404,7 +404,7 @@ class ProcessingTest_AutoapplyActions(unittest.TestCase):
                                 {},
                                 self.section,
                                 self.log_printer)
-        self.assertEqual(ret, [self.resultZ])
+        self.assertEqual(ret, self.results)
         self.assertEqual(self.log_queue.get().message,
                          "Failed to execute action 'FailingTestAction'.")
         self.assertIn("YEAH THAT'S A FAILING BEAR",


### PR DESCRIPTION
If an auto-apply action fails due to a raised exception, it's
considered unprocessed.