### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
 include README.md
+include LICENSE
+include requirements.txt
+include setup.cfg
 recursive-include docs *

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyPrint==0.1.0
+PyPrint==0.1.1
 setuptools==19.2
 munkres3==1.0.5.5
 coverage==4.0.3


### PR DESCRIPTION
The requirements.txt is needed for setup execution and thus must be
included in the distribution. The other files are just nice to include
in a distribution... especially the license.

Another commit will be added soon which will upgrade pyprint to 0.1.1 as soon as it's out.