### PR TITLE
SpaceConsistencyBear: Remove "Trailing Whitespace"

### DIFF
--- a/bears/general/SpaceConsistencyBear.py
+++ b/bears/general/SpaceConsistencyBear.py
@@ -41,9 +41,8 @@ class SpaceConsistencyBear(LocalBear):
                     result_texts.append("No newline at EOF.")
 
             if not allow_trailing_whitespace:
-                pre_replacement = line
                 replacement = replacement.rstrip(" \t\n") + "\n"
-                if replacement != pre_replacement:
+                if replacement != line.rstrip("\n") + "\n":
                     result_texts.append("Trailing whitespaces.")
 
             if use_spaces:


### PR DESCRIPTION
SpaceConsistencyBear shows "Trailing Whitespace" when
new line is missing.This is taken care of by comparing
the replacement with the original line with stripped off
new line and by adding a new line at the end.

Fixes https://github.com/coala-analyzer/coala/issues/1185