### PR TITLE
Show relative path in results output

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -18,6 +18,7 @@ from coalib.results.result_actions.ApplyPatchAction import ApplyPatchAction
 from coalib.results.result_actions.PrintDebugMessageAction import (
     PrintDebugMessageAction)
 from coalib.results.result_actions.ShowPatchAction import ShowPatchAction
+import os.path
 
 
 STR_GET_VAL_FOR_SETTING = ("Please enter a value for the setting \"{}\" ({}) "
@@ -238,7 +239,8 @@ def print_results(log_printer,
 
 
 def print_affected_lines(console_printer, file_dict, sourcerange):
-    console_printer.print("\n" + sourcerange.file, color=FILE_NAME_COLOR)
+    console_printer.print("\n" + os.path.relpath(sourcerange.file),
+                          color=FILE_NAME_COLOR)
 
     if sourcerange.start.line is not None:
         if len(file_dict[sourcerange.file]) < sourcerange.end.line:

--- a/coalib/tests/output/ConsoleInteractionTest.py
+++ b/coalib/tests/output/ConsoleInteractionTest.py
@@ -274,12 +274,12 @@ class ConsoleInteractionTest(unittest.TestCase):
                 Section(""),
                 [Result.from_values("SpaceConsistencyBear",
                                     "Trailing whitespace found",
-                                    file="proj/white",
+                                    file="filename",
                                     line=2)],
-                {"proj/white": ["test line\n", "line 2\n", "line 3\n"]},
+                {"filename": ["test line\n", "line 2\n", "line 3\n"]},
                 {},
                 color=False)
-            self.assertEqual("""\nproj/white
+            self.assertEqual("""\nfilename
 |   2| line 2
 |    | [NORMAL] SpaceConsistencyBear:
 |    | Trailing whitespace found
@@ -292,16 +292,16 @@ class ConsoleInteractionTest(unittest.TestCase):
                 Section(""),
                 [Result.from_values("SpaceConsistencyBear",
                                     "Trailing whitespace found",
-                                    file="proj/white",
+                                    file="filename",
                                     line=5)],
-                {"proj/white": ["test line\n",
-                                "line 2\n",
-                                "line 3\n",
-                                "line 4\n",
-                                "line 5\n"]},
+                {"filename": ["test line\n",
+                              "line 2\n",
+                              "line 3\n",
+                              "line 4\n",
+                              "line 5\n"]},
                 {},
                 color=False)
-            self.assertEqual("""\nproj/white
+            self.assertEqual("""\nfilename
 |   5| line 5
 |    | [NORMAL] SpaceConsistencyBear:
 |    | Trailing whitespace found


### PR DESCRIPTION
related to coala-analyzer #1124

Shows relative path in the results, does not have an option(as of now) to show absolute paths.