### PR TITLE
SourcePosition: Use absoloute path for the file parameter

### DIFF
--- a/coalib/results/SourcePosition.py
+++ b/coalib/results/SourcePosition.py
@@ -1,3 +1,5 @@
+import os
+
 from coalib.misc.Decorators import (enforce_signature,
                                     generate_ordering,
                                     generate_repr)
@@ -24,7 +26,7 @@ class SourcePosition(TextPosition):
         """
         TextPosition.__init__(self, line, column)
 
-        self._file = file
+        self._file = os.path.abspath(file)
 
     @property
     def file(self):

--- a/coalib/tests/output/ConsoleInteractionTest.py
+++ b/coalib/tests/output/ConsoleInteractionTest.py
@@ -1,6 +1,7 @@
 import unittest
 import sys
 import os
+from os.path import abspath
 from collections import OrderedDict
 from pyprint.NullPrinter import NullPrinter
 from pyprint.ConsolePrinter import ConsolePrinter
@@ -278,7 +279,7 @@ class ConsoleInteractionTest(unittest.TestCase):
                                     "Trailing whitespace found",
                                     file="filename",
                                     line=2)],
-                {"filename": ["test line\n", "line 2\n", "line 3\n"]},
+                {abspath("filename"): ["test line\n", "line 2\n", "line 3\n"]},
                 {},
                 color=False)
             self.assertEqual("""\nfilename
@@ -296,11 +297,11 @@ class ConsoleInteractionTest(unittest.TestCase):
                                     "Trailing whitespace found",
                                     file="filename",
                                     line=5)],
-                {"filename": ["test line\n",
-                              "line 2\n",
-                              "line 3\n",
-                              "line 4\n",
-                              "line 5\n"]},
+                {abspath("filename"): ["test line\n",
+                                       "line 2\n",
+                                       "line 3\n",
+                                       "line 4\n",
+                                       "line 5\n"]},
                 {},
                 color=False)
             self.assertEqual("""\nfilename
@@ -322,11 +323,11 @@ class ConsoleInteractionTest(unittest.TestCase):
                                               "Trailing whitespace found",
                                               file="file",
                                               line=2)],
-                          {"file": ["test line\n",
-                                    "line 2\n",
-                                    "line 3\n",
-                                    "line 4\n",
-                                    "line 5\n"]},
+                          {abspath("file"): ["test line\n",
+                                             "line 2\n",
+                                             "line 3\n",
+                                             "line 4\n",
+                                             "line 5\n"]},
                           {},
                           color=False)
 
@@ -344,9 +345,10 @@ file
                              stdout.getvalue())
 
     def test_print_results_multiple_ranges(self):
-        affected_code = (SourceRange.from_values("some_file", 5, end_line=7),
-                         SourceRange.from_values("another_file", 1, 3, 1, 5),
-                         SourceRange.from_values("another_file", 3, 3, 3, 5))
+        affected_code = (
+            SourceRange.from_values("some_file", 5, end_line=7),
+            SourceRange.from_values("another_file", 1, 3, 1, 5),
+            SourceRange.from_values("another_file", 3, 3, 3, 5))
         with retrieve_stdout() as stdout:
             print_results(
                 self.log_printer,
@@ -354,8 +356,10 @@ file
                 [Result("ClangCloneDetectionBear",
                         "Clone Found",
                         affected_code)],
-                {"some_file": ["line "+str(i+1)+"\n" for i in range(10)],
-                 "another_file": ["line "+str(i+1)+"\n" for i in range(10)]},
+                {abspath("some_file"): ["line " + str(i + 1) + "\n"
+                                        for i in range(10)],
+                 abspath("another_file"): ["line " + str(i + 1) + "\n"
+                                           for i in range(10)]},
                 {},
                 color=False)
             self.assertEqual("""
@@ -401,7 +405,7 @@ some_file
                 Section(""),
                 [Result.from_values("t", "msg", file="file", line=5),
                  Result.from_values("t", "msg", file="file", line=6)],
-                {"file": ["line " + str(i+1) for i in range(5)]},
+                {abspath("file"): ["line " + str(i + 1) for i in range(5)]},
                 {},
                 color=False)
             self.assertEqual("\n"
@@ -422,7 +426,7 @@ some_file
                 self.log_printer,
                 Section(""),
                 [Result.from_values("t", "msg", file="file")],
-                {"file": []},
+                {abspath("file"): []},
                 {},
                 color=False)
             self.assertEqual(
@@ -561,10 +565,10 @@ class PrintFormattedResultsTest(unittest.TestCase):
 
     def test_multiple_ranges(self):
         expected_string = (
-            "id:-?[0-9]+:origin:1:file:another_file:from_line:5:"
+            "id:-?[0-9]+:origin:1:.*file:.*another_file:from_line:5:"
             "from_column:3:to_line:5:to_column:5:"
             "severity:1:msg:2\n"
-            "id:-?[0-9]+:origin:1:file:some_file:from_line:5:"
+            "id:-?[0-9]+:origin:1:.*file:.*some_file:from_line:5:"
             "from_column:None:to_line:7:to_column:None:"
             "severity:1:msg:2\n")
         affected_code = (SourceRange.from_values("some_file", 5, end_line=7),

--- a/coalib/tests/results/ResultFilterTest.py
+++ b/coalib/tests/results/ResultFilterTest.py
@@ -1,4 +1,5 @@
 import os
+from os.path import abspath
 import sys
 import unittest
 
@@ -67,7 +68,7 @@ class ResultFilterTest(unittest.TestCase):
             severity=RESULT_SEVERITY.NORMAL,
             debug_msg="another debug message")
 
-        file_dict = {"original": []}
+        file_dict = {abspath("original"): []}
 
         self.assertEqual(filter_results(original_file_dict=file_dict,
                                         modified_file_dict=file_dict,
@@ -355,11 +356,11 @@ class ResultFilterTest(unittest.TestCase):
 
         with open(self.original_file_name, "r") as original_file:
             original_file_dict = {
-                "file_name": original_file.readlines()}
+                abspath("file_name"): original_file.readlines()}
 
             with open(self.modified_file_name, "r") as modified_file:
                 modified_file_dict = {
-                    "file_name": modified_file.readlines()}
+                    abspath("file_name"): modified_file.readlines()}
 
                 # 'TIS THE IMPORTANT PART
                 self.assertEqual(sorted(filter_results(original_file_dict,
@@ -448,7 +449,7 @@ class ResultFilterTest(unittest.TestCase):
 
     def test_result_range_inline_overlap(self):
         test_file = ["123456789\n"]
-        test_file_dict = {"test_file": test_file}
+        test_file_dict = {abspath("test_file"): test_file}
 
         source_range1 = SourceRange.from_values("test_file", 1, 1, 1, 4)
         source_range2 = SourceRange.from_values("test_file", 1, 2, 1, 3)
@@ -459,15 +460,15 @@ class ResultFilterTest(unittest.TestCase):
                              (source_range1, source_range2, source_range3))
 
         result_diff = remove_result_ranges_diffs(
-                [test_result],
-                test_file_dict)[test_result]["test_file"]
+            [test_result],
+            test_file_dict)[test_result][abspath("test_file")]
         expected_diff = Diff.from_string_arrays(test_file, ["789\n"])
 
         self.assertEqual(result_diff, expected_diff)
 
     def test_result_range_line_wise_overlap(self):
         test_file = ["11", "22", "33", "44", "55", "66"]
-        test_file_dict = {"test_file": test_file}
+        test_file_dict = {abspath("test_file"): test_file}
 
         source_range1 = SourceRange.from_values("test_file", 2, 2, 5, 1)
         source_range2 = SourceRange.from_values("test_file", 3, 1, 4, 1)
@@ -477,8 +478,8 @@ class ResultFilterTest(unittest.TestCase):
                              (source_range1, source_range2))
 
         result_diff = remove_result_ranges_diffs(
-                [test_result],
-                test_file_dict)[test_result]["test_file"]
+            [test_result],
+            test_file_dict)[test_result][abspath("test_file")]
         expected_diff = Diff.from_string_arrays(test_file,
                                                 ["11", "2", "5", "66"])
 
@@ -486,14 +487,14 @@ class ResultFilterTest(unittest.TestCase):
 
     def test_no_range(self):
         test_file = ["abc"]
-        test_file_dict = {"test_file": test_file}
+        test_file_dict = {abspath("test_file"): test_file}
 
         test_result = Result("origin",
                              "message")
 
         result_diff = remove_result_ranges_diffs(
-                [test_result],
-                test_file_dict)[test_result]["test_file"]
+            [test_result],
+            test_file_dict)[test_result][abspath("test_file")]
         expected_diff = Diff.from_string_arrays(test_file, ["abc"])
 
         self.assertEqual(result_diff, expected_diff)

--- a/coalib/tests/results/ResultTest.py
+++ b/coalib/tests/results/ResultTest.py
@@ -1,3 +1,4 @@
+from os.path import abspath
 import sys
 import unittest
 
@@ -44,7 +45,7 @@ class ResultTest(unittest.TestCase):
         self.assertEqual(output, {"id": str(uut.id),
                                   "origin": "origin",
                                   "message": "msg",
-                                  "file": "file",
+                                  "file": abspath("file"),
                                   "line_nr": "2",
                                   "severity": "INFO",
                                   "debug_msg": "dbg"})

--- a/coalib/tests/results/SourcePositionTest.py
+++ b/coalib/tests/results/SourcePositionTest.py
@@ -23,13 +23,13 @@ class SourcePositionTest(unittest.TestCase):
         uut = SourcePosition("filename", 1)
         self.assertRegex(
             repr(uut),
-            "<SourcePosition object\\(file='filename', line=1, column=None\\) "
-                "at 0x[0-9a-fA-F]+>")
+            "<SourcePosition object\\(file='.*filename', line=1, "
+                "column=None\\) at 0x[0-9a-fA-F]+>")
 
         uut = SourcePosition("None", None)
         self.assertRegex(
             repr(uut),
-            "<SourcePosition object\\(file='None', line=None, column=None\\) "
+            "<SourcePosition object\\(file='.*None', line=None, column=None\\) "
                 "at 0x[0-9a-fA-F]+>")
 
     def assert_equal(self, first, second):

--- a/coalib/tests/results/SourceRangeTest.py
+++ b/coalib/tests/results/SourceRangeTest.py
@@ -43,7 +43,7 @@ class SourceRangeTest(unittest.TestCase):
 
     def test_file_property(self):
         uut = SourceRange(self.result_fileA_line2)
-        self.assertEqual(uut.file, "A")
+        self.assertRegex(uut.file, ".*A")
 
     def test_invalid_arguments(self):
         # arguments must be SourceRanges


### PR DESCRIPTION
If absoloute path is not used, then comparison wouldn't work
between two SourceRanges, because the paths may be different.