### PR TITLE
CodeStyle: replace filehandler with the more mnemonic file

### DIFF
--- a/coalib/results/result_actions/OpenEditorAction.py
+++ b/coalib/results/result_actions/OpenEditorAction.py
@@ -43,8 +43,8 @@ class OpenEditorAction(ApplyPatchAction):
             subprocess.call(editor_args)
 
         for filename in filenames:
-            with open(filename) as filehandle:
-                new_file = filehandle.readlines()
+            with open(filename) as file:
+                new_file = file.readlines()
 
             original_file = original_file_dict[filename]
             try:

--- a/coalib/tests/output/ConfWriterTest.py
+++ b/coalib/tests/output/ConfWriterTest.py
@@ -25,8 +25,8 @@ class ConfWriterTest(unittest.TestCase):
 
     def setUp(self):
         self.file = os.path.join(tempfile.gettempdir(), "ConfParserTestFile")
-        with open(self.file, "w", encoding='utf-8') as filehandler:
-            filehandler.write(self.example_file)
+        with open(self.file, "w", encoding='utf-8') as file:
+            file.write(self.example_file)
 
         self.conf_parser = ConfParser()
         self.write_file_name = os.path.join(tempfile.gettempdir(),

--- a/coalib/tests/parsing/ConfParserTest.py
+++ b/coalib/tests/parsing/ConfParserTest.py
@@ -35,8 +35,8 @@ class ConfParserTest(unittest.TestCase):
         self.tempdir = tempfile.gettempdir()
         self.file = os.path.join(self.tempdir, ".coafile")
         self.nonexistentfile = os.path.join(self.tempdir, "e81k7bd98t")
-        with open(self.file, "w") as filehandler:
-            filehandler.write(self.example_file)
+        with open(self.file, "w") as file:
+            file.write(self.example_file)
 
         self.uut = ConfParser()
         try:


### PR DESCRIPTION
In many places, filehandler(r) is used when opening a file:

with open(..) as filehandler:

This is replaced with the word file, which is more semantic:

with open(..) as file: