### PR TITLE
Added PHP and Objective-C in doxygen.coalang

### DIFF
--- a/coalib/bearlib/languages/documentation/doxygen.coalang
+++ b/coalib/bearlib/languages/documentation/doxygen.coalang
@@ -44,3 +44,19 @@ doc-marker = \#\#, \#, \#
 
 [VHDL]
 doc-marker = --!, --!, --!
+
+[PHP]
+doc-marker1 = /**, \ *, \ */
+doc-marker2 = /**, , \ */
+doc-marker3 = /*!, \ *, \ */
+doc-marker4 = /*!, , \ */
+doc-marker5 = ///, ///, ///
+doc-marker6 = //!, //!, //!
+
+[OBJECTIVE-C]
+doc-marker1 = /**, \ *, \ */
+doc-marker2 = /**, , \ */
+doc-marker3 = /*!, \ *, \ */
+doc-marker4 = /*!, , \ */
+doc-marker5 = ///, ///, ///
+doc-marker6 = //!, //!, //!


### PR DESCRIPTION
Closed  Issue #1143 
As Objective-C and PHP are C-styled languages , their commenting style is same as of java and c++ 
: referred Doxygen Manual 1.8.11