### PR TITLE
codestyle: Use builtin vars() instead of __dict__

### DIFF
--- a/coalib/tests/settings/FunctionMetadataTest.py
+++ b/coalib/tests/settings/FunctionMetadataTest.py
@@ -33,9 +33,9 @@ class FunctionMetadataTest(unittest.TestCase):
     def test_from_function(self):
         uut = FunctionMetadata.from_function(self.test_from_function)
         self.check_function_metadata_data_set(uut, "test_from_function")
-        # setattr on bound methods will fail, __dict__ will use the dict from
+        # setattr on bound methods will fail, vars() will use the dict from
         # the unbound method which is ok.
-        self.test_from_function.__dict__["__metadata__"] = (
+        vars(self.test_from_function)["__metadata__"] = (
             FunctionMetadata("t"))
         uut = FunctionMetadata.from_function(self.test_from_function)
         self.check_function_metadata_data_set(uut, "t")


### PR DESCRIPTION
this is about #971

there are 3 more usages of `__dict__` in our code, but those cannot be replaced (like `hasattr(__dict__)`).

We have 4 usages of `__len__` but all of them are function definitions, so that seems to be it