### PR TITLE
Documentation: Example correction in CodeStyle for area calculation

### DIFF
--- a/docs/Getting_Involved/Codestyle.md
+++ b/docs/Getting_Involved/Codestyle.md
@@ -21,7 +21,7 @@ same column.
 Example:
 
 ```
-def area(height, breadth):
+def area(length, breadth):
     """
     Finds the area of a rectangle of the given length and breadth.
 


### PR DESCRIPTION
The documentation example mentioned area of rectangle as
`height` * `breadth` but the documentation was mentioned as
`length` in place of `height`, Ideally it should be `length` and 
product with `height`. This patch fixes the documentation for
this problem.

Fixes https://github.com/coala-analyzer/coala/issues/1269