### PR TITLE
Setup.py: Locale get and set avoids unicode error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import locale
 from setuptools import setup, find_packages
 import setuptools.command.build_py
 
@@ -8,6 +9,11 @@ assert_supported_version()
 from coalib.misc.BuildManPage import BuildManPage
 from coalib.output.dbus.BuildDbusService import BuildDbusService
 from coalib.misc import Constants
+
+try:
+    locale.getlocale()
+except (ValueError, UnicodeError):
+    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
 
 
 class BuildPyCommand(setuptools.command.build_py.build_py):


### PR DESCRIPTION
Installations on virtualenv result in errors on Mac and Windows
for unicode decode errors thrown by missing locales, This can
be resolved by adding locale before the setup.

Fixes: https://github.com/coala-analyzer/coala/issues/1268