### PR TITLE
Install.md: Add setuptools documentation

### DIFF
--- a/docs/Users/Install.md
+++ b/docs/Users/Install.md
@@ -44,6 +44,13 @@ You can now install coala with a simple:
 python3 setup.py install
 ```
 
+For the above to work, you may also need to install `setuptools` which can be
+installed by running
+
+```
+pip3 install setuptools
+```
+
 You will have coala installed into your python scripts directory. On an unixoid
 system it is probably already available on your command line globally.
 


### PR DESCRIPTION
Some users can face a problem with setuptools throwing an error
This can be fixed by installing setup tools. This patch updates
the documentation for fixing errors for no module named
setuptools.

Fixes https://github.com/coala-analyzer/coala/issues/1288