### PR TITLE
find_user_config: handle files and directories properly

### DIFF
--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -176,7 +176,7 @@ def find_user_config(file_path, max_trials=10):
     file_path = os.path.normpath(os.path.abspath(os.path.expanduser(
         file_path)))
     old_dir = None
-    base_dir = os.path.dirname(file_path)
+    base_dir = file_path
     home_dir = os.path.expanduser("~")
 
     while base_dir != old_dir and old_dir != home_dir and max_trials != 0:

--- a/coalib/tests/settings/ConfigurationGatheringTest.py
+++ b/coalib/tests/settings/ConfigurationGatheringTest.py
@@ -213,8 +213,7 @@ class ConfigurationGatheringTest(unittest.TestCase):
         current_dir = os.path.abspath(os.path.dirname(__file__))
         c_file = os.path.join(current_dir,
                               "section_manager_test_files",
-                              "project",
-                              "test.c")
+                              "project")
 
         retval = find_user_config(c_file, 1)
         self.assertEqual("", retval)


### PR DESCRIPTION
Starting search directory should be file_path, not the base directory of the file_path (which is one level behind).
Also, initially, ConfigurationGatheringTest.py tested find_user_config
with a file as file_path (instead of a directory). That should not
be the case since all usages of find_user_config pass directories
check:
coalib/output/dbus/DbusDocument.py:47
coalib/settings/ConfigurationGathering.py:121

Fixes https://github.com/coala-analyzer/coala/issues/1246