### PR TITLE
coalib: Add flag -o to coala-json

### DIFF
--- a/coalib/coala_json.py
+++ b/coalib/coala_json.py
@@ -34,10 +34,19 @@ def main():
     if not args.text_logs:
         retval["logs"] = log_printer.logs
 
-    print(json.dumps(retval,
-                     cls=JSONEncoder,
-                     sort_keys=True,
-                     indent=2,
-                     separators=(',', ': ')))
+    if args.output:
+        filename = str(args.output)
+        with open(filename, 'w+') as fp:
+            json.dump(retval, fp,
+                      cls=JSONEncoder,
+                      sort_keys=True,
+                      indent=2,
+                      separators=(',', ': '))
+    else:
+        print(json.dumps(retval,
+                         cls=JSONEncoder,
+                         sort_keys=True,
+                         indent=2,
+                         separators=(',', ': ')))
 
     return exitcode

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -106,6 +106,13 @@ def default_arg_parser(formatter_class=None):
                                 metavar='BOOL',
                                 help='Don\'t display logs as json, display '
                                      'them as we normally do in the console.')
+        arg_parser.add_argument('-o',
+                                '--output',
+                                nargs='?',
+                                const=True,
+                                metavar='BOOL',
+                                help='Write the logs as json to a file '
+                                'where filename is specified as argument.')
     if parser_type == 'coala':
         SHOW_BEARS_HELP = ("Display bears and its metadata with the sections "
                            "that they belong to")

--- a/coalib/tests/coalaJSONTest.py
+++ b/coalib/tests/coalaJSONTest.py
@@ -61,3 +61,25 @@ class coalaJSONTest(unittest.TestCase):
         self.assertRegex(
             output,
             ".*\\[ERROR\\].*The requested coafile '.*' does not exist.\n")
+
+    def test_output_file(self):
+        with prepare_file(["#todo this is todo"], None) as (lines, filename):
+            retval, output = execute_coala(coala_json.main, "coala-json",
+                                           "-c", os.devnull,
+                                           "-b", "LineCountTestBear",
+                                           "-f", re.escape(filename))
+            exp_retval, exp_output = execute_coala(coala_json.main,
+                                                   "coala-json",
+                                                   "-c", os.devnull,
+                                                   "-b", "LineCountTestBear",
+                                                   "-f", re.escape(filename),
+                                                   "-o", "file.json")
+
+        with open('file.json') as fp:
+            data = json.load(fp)
+
+        output = json.loads(output)
+
+        self.assertEqual(data['logs'][0]['log_level'],
+                         output['logs'][0]['log_level'])
+        os.remove('file.json')


### PR DESCRIPTION
Add an argument option -o to coala-json to open a json file
and write the required output into the json file.
Add documentation on failure of the command telling correct
command coala-json to be executed
coala-json will display json data to console
coala-json -o filename.json implementation displays success message

Fixes https://github.com/coala-analyzer/coala/issues/846