### PR TITLE
Collectors: Add limit_paths() & expose it in args

### DIFF
--- a/coalib/collecting/Collectors.py
+++ b/coalib/collecting/Collectors.py
@@ -45,16 +45,19 @@ def icollect(file_paths):
             yield match
 
 
-def collect_files(file_paths, ignored_file_paths=None):
+def collect_files(file_paths, ignored_file_paths=None, limit_file_paths=None):
     """
     Evaluate globs in file paths and return all matching files
 
     :param file_paths:         file path or list of such that can include globs
     :param ignored_file_paths: list of globs that match to-be-ignored files
+    :param limit_file_paths:   list of globs that the files are limited to
     :return:                   list of paths of all matching files
     """
     valid_files = list(filter(os.path.isfile, icollect(file_paths)))
-    return remove_ignored(valid_files, ignored_file_paths or [])
+    valid_files = remove_ignored(valid_files, ignored_file_paths or [])
+    valid_files = limit_paths(valid_files, limit_file_paths or [])
+    return valid_files
 
 
 def collect_dirs(dir_paths, ignored_dir_paths=None):
@@ -128,3 +131,23 @@ def remove_ignored(file_paths, ignored_globs):
                 break
 
     return reduced_list
+
+
+def limit_paths(file_paths, limit_globs):
+    """
+    Limits file paths from list based on the given globs.
+
+    :param file_paths:  file path string or list of such
+    :param limit_globs: list of globs to limit the file paths by
+    :return:            list with only those items that in the limited globs
+    """
+    file_paths = list(set(file_paths))
+    limited_list = file_paths[:]
+
+    for file_path in file_paths:
+        for limit_glob in limit_globs:
+            if not fnmatch(file_path, limit_glob):
+                limited_list.remove(file_path)
+                break
+
+    return limited_list

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -43,6 +43,12 @@ def default_arg_parser(formatter_class=None):
                             nargs='+',
                             metavar='FILE',
                             help='Files that should be ignored')
+    arg_parser.add_argument('--limit-files',
+                            nargs='+',
+                            metavar='FILE',
+                            help='Files that will be analyzed will be '
+                                 'restricted to those in the globs listed '
+                                 'in this argument as well the files setting')
     arg_parser.add_argument('-b',
                             '--bears',
                             nargs='+',

--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -306,8 +306,10 @@ def instantiate_processes(section,
                              and the arguments passed to each process which are
                              the same for each object.
     """
-    filename_list = collect_files(path_list(section.get('files', "")),
-                                  path_list(section.get('ignore', "")))
+    filename_list = collect_files(
+        path_list(section.get('files', "")),
+        ignored_file_paths=path_list(section.get('ignore', "")),
+        limit_file_paths=path_list(section.get('limit_files', "")))
     file_dict = get_file_dict(filename_list, log_printer)
 
     manager = multiprocessing.Manager()

--- a/coalib/tests/collecting/CollectorsTest.py
+++ b/coalib/tests/collecting/CollectorsTest.py
@@ -60,6 +60,22 @@ class CollectFilesTest(unittest.TestCase):
                                                      "file2.py")]),
                          [])
 
+    def test_limited(self):
+        self.assertEqual(
+            collect_files([os.path.join(self.collectors_test_dir,
+                                        "others",
+                                        "*",
+                                        "*py")],
+                          limit_file_paths=[os.path.join(
+                                                self.collectors_test_dir,
+                                                "others",
+                                                "*",
+                                                "*2.py")]),
+            [os.path.normcase(os.path.join(self.collectors_test_dir,
+                                           "others",
+                                           "py_files",
+                                           "file2.py"))])
+
 
 class CollectDirsTest(unittest.TestCase):
 


### PR DESCRIPTION
Currently there is not method to limit the files which coala would run on
in the command line arguments (without changing the coafile). This commit
adds a new argument namely "--limit-files" which ensures that coala does
not analyze any file outside the glob patterns mentioned in this argument.

This is useful specially when coala's analysis is required in only 1 file
like in the case of editor plugins.

Fixes https://github.com/coala-analyzer/coala/issues/1315