### PR TITLE
Appveyor clean up the PATH setting.

### DIFF
--- a/.misc/appveyor.yml
+++ b/.misc/appveyor.yml
@@ -24,8 +24,9 @@ install:
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart
   # the parent CMD process).
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;C:\\Program\ Files\\Java\\jdk1.7.0\\bin;%PATH%"
-  - SET PATH=%GOROOT%\bin;%PATH%
+  - "SET PATH=%GOROOT%\bin;%PATH%"
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "SET PATH=C:\\Program\ Files\\Java\\jdk1.7.0\\bin;%PATH%"
   - go get -u github.com/golang/lint/golint
   # language-tool needs the registry tweaked here since it determines the java
   # version wrong (since appveyor has both, 1.7 and 1.8 in x86 and x64).


### PR DESCRIPTION
appveyor.yml: Appveyor clean up the PATH setting
change `appveyor.yml` for better readibility so that python paths are added in one line and Java paths are added in the next line
    
Fixes https://github.com/coala-analyzer/coala/issues/1334