### PR TITLE
package.json: Add a package.json file to coala

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "jshint": "~2.9.1",
+    "alex" : "~2.0.1",
+    "remark": "~3.2.3",
+    "dockerfile_lint":"~0.0.9",
+    "csslint" : "~0.10.0",
+    "coffeelint" : "~1.14.2"
+  }
+}


### PR DESCRIPTION
`package.json` would make it easy for users to install
nodejs dependencies using `npm install` or `npm install -g`

Fixes https://github.com/coala-analyzer/coala/issues/1328