### PR TITLE
pytest: Run on multiple cores simultaneously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ MANIFEST
 *.patch
 _build
 coverage.xml
-.htmlreport
+htmlcov
 *.orig
 *.diff
 *.kdev4

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+import os
+import webbrowser
+
+
+def pytest_unconfigure(config):
+    htmlcov_path = os.path.join("htmlcov", "index.html")
+    if 'html' in config.option.cov_report and os.path.isfile(htmlcov_path):
+        try:
+            webbrowser.open_new_tab(htmlcov_path)
+        except webbrowser.Error:
+            pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,9 @@ addopts =
     --color=yes
     --doctest-glob=*.rst
     --ignore=coalib/tests/collecting/collectors_test_dir/bears/incorrect_bear.py
+env =
+    PYTHONHASHSEED=0
+# PYTHONHASHSEED=0 is required to use same hashes in pytests-xdist's workers
 
 [coverage:run]
 branch = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,3 @@ omit = */tests/*
 
 [coverage:report]
 show_missing = True
-
-[coverage:html]
-directory = .htmlreport

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,6 @@
 coverage==4.0.3
 pytest==2.8.7
 pytest-cov==2.2.1
+pytest-env==0.6.0
 pytest-timeout==1.0.0
+pytest-xdist==1.14


### PR DESCRIPTION
Run pytest on multiple cores simultaneously using pytest-xdist
Due to undeterministic line of LocalBearTestHlper based
tests, we set PYTHONHASHSEED=0 to remove randomness from
hashes being computed in python.

Fixes https://github.com/coala-analyzer/coala/issues/1407