### PR TITLE
tests.sh: Allow PyLint Test for 3.5

### DIFF
--- a/.misc/tests.sh
+++ b/.misc/tests.sh
@@ -13,9 +13,6 @@ source .misc/env_variables.sh
 
 args=()
 
-if [ "$python_version" == "3.5" ] ; then
-  args+=('-k' 'not PyLintBearTest')
-fi
 if [ "$system_os" == "LINUX" ] ; then
   args+=('--cov' '--doctest-modules')
 fi


### PR DESCRIPTION
Python 3.5 now supports PyLint. So, remove the skip.

Fixes https://github.com/coala-analyzer/coala/issues/1452