### PR TITLE
.misc: Add missing goimports

### DIFF
--- a/.misc/appveyor.yml
+++ b/.misc/appveyor.yml
@@ -28,6 +28,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "SET PATH=C:\\Program\ Files\\Java\\jdk1.7.0\\bin;%PATH%"
   - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/tools/cmd/goimports
   # language-tool needs the registry tweaked here since it determines the java
   # version wrong (since appveyor has both, 1.7 and 1.8 in x86 and x64).
   - "SET KEY_NAME=HKLM\\Software\\JavaSoft\\Java Runtime Environment"

--- a/.misc/deps.osx.sh
+++ b/.misc/deps.osx.sh
@@ -26,6 +26,7 @@ brew install go
 
 # Install required go libraries
 go get -u github.com/golang/lint/golint
+go get -u golang.org/x/tools/cmd/goimports
 
 # Start dbus in the system
 launchctl load -w `find /usr/local/Cellar/d-bus -name "org.freedesktop.dbus-session.plist"`


### PR DESCRIPTION
GoImports added to deps.osx and appveyor build for travis
and appveyor to pass the goimports test.