### PR TITLE
.coafile: Update coafile to change docs extension

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -30,7 +30,7 @@ bears = LineLengthBear
 [DOCS]
 bears = SpaceConsistencyBear
 
-files = docs/**/*.md
+files = docs/**/*.rst
 default_actions = SpaceConsistencyBear: ApplyPatchAction
 
 [commit]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,13 +9,13 @@ Welcome to the coala documentation!
 .. toctree::
    :caption: Home
    :hidden:
-   
+
    Welcome <self>
 
 .. toctree::
    :caption: For Users
    :hidden:
-   
+
    Installation <Users/Install>
    coafile Specification <Users/coafile>
    Glob Patterns <Users/Glob_Patterns>
@@ -25,7 +25,7 @@ Welcome to the coala documentation!
 .. toctree::
    :caption: Tutorials
    :hidden:
-   
+
    First Step <Users/Tutorials/Tutorial>
    Writing Bears <Users/Tutorials/Writing_Bears>
    Linter Bears <Users/Tutorials/Linter_Bears>
@@ -33,7 +33,7 @@ Welcome to the coala documentation!
 .. toctree::
    :caption: Getting Involved
    :hidden:
-   
+
    Introduction <Getting_Involved/README>
    Review <Getting_Involved/Review>
    Codestyle <Getting_Involved/Codestyle>
@@ -46,13 +46,13 @@ Welcome to the coala documentation!
 .. toctree::
    :caption: General Developer Information
    :hidden:
-   
+
    A Hitchhiker's Guide to Git (1): Genesis <General_Dev_Info/git_tutorial_1>
 
 .. toctree::
    :caption: API Documentation
    :hidden:
-   
+
    List of Modules<API/modules>
 
 ::


### PR DESCRIPTION
Migration from md to rst docs has to be updated in .coafile to run coala
on docs (rst files).

Fixes https://github.com/coala-analyzer/coala/issues/1341