### PR TITLE
coala_dbus: Move lambdas to functions

### DIFF
--- a/coalib/coala_dbus.py
+++ b/coalib/coala_dbus.py
@@ -22,6 +22,14 @@ from coalib.output.dbus.DbusServer import DbusServer
 from coalib.misc import Constants
 
 
+def sys_clean_exit():
+    sys.exit(0)
+
+
+def on_disconnected():
+    return GLib.idle_add(sys_clean_exit)
+
+
 def main():
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
 
@@ -33,7 +41,7 @@ def main():
         session_bus)
     DbusServer(session_bus,
                '/org/coala_analyzer/v1',
-               on_disconnected=lambda: GLib.idle_add(lambda: sys.exit(0)))
+               on_disconnected=on_disconnected)
 
     mainloop = GLib.MainLoop()
     mainloop.run()

--- a/coalib/tests/coalaDbusTest.py
+++ b/coalib/tests/coalaDbusTest.py
@@ -28,3 +28,8 @@ class coalaDbusTest(unittest.TestCase):
         # Ensure we are able to setup dbus and create a mainloop
         with self.assertRaises(AssertionError):
             coala_dbus.main()
+
+        with self.assertRaises(SystemExit):
+            coala_dbus.sys_clean_exit()
+
+        self.assertGreater(coala_dbus.on_disconnected(), 0)


### PR DESCRIPTION
Move lambdas to functions so that they can be tested in
coalaDbusTest.py