### PR TITLE
OpenEditorAction.py : Update Success Message

### DIFF
--- a/coalib/results/result_actions/OpenEditorAction.py
+++ b/coalib/results/result_actions/OpenEditorAction.py
@@ -17,7 +17,7 @@ GUI_EDITORS = ["kate", "gedit", "subl", "atom"]
 
 class OpenEditorAction(ApplyPatchAction):
 
-    success_message = "Editor opened successfully."
+    success_message = "We got your changes from the Editor."
 
     @staticmethod
     def is_applicable(result, original_file_dict, file_diff_dict):


### PR DESCRIPTION
It currently uses Editor opened successfully.
Changed to - we got your changes from the editor.

Fixes https://github.com/coala-analyzer/coala/issues/1474