### PR TITLE
LineLengthBear: Search anywhere in string

### DIFF
--- a/bears/general/LineLengthBear.py
+++ b/bears/general/LineLengthBear.py
@@ -3,6 +3,7 @@ import re
 from coalib.bearlib.spacing.SpacingHelper import SpacingHelper
 from coalib.bears.LocalBear import LocalBear
 from coalib.results.Result import Result
+from coalib.settings.Setting import typed_list
 
 
 class LineLengthBear(LocalBear):
@@ -12,22 +13,22 @@ class LineLengthBear(LocalBear):
             file,
             max_line_length: int=80,
             tab_width: int=SpacingHelper.DEFAULT_TAB_WIDTH,
-            ignore_length_regex: str=''):
+            ignore_length_regex: typed_list(str)=()):
         '''
         Yields results for all lines longer than the given maximum line length.
 
         :param max_line_length:     Maximum number of characters for a line.
         :param tab_width:           Number of spaces to show for one tab.
-        :param ignore_length_regex: All lines matching this regular expression
-                                    will be ignored.
+        :param ignore_length_regex: Lines matching each of the regular
+                                    expressions in this list will be ignored.
         '''
         spacing_helper = SpacingHelper(tab_width)
-        ignore_regex = re.compile(ignore_length_regex)
+        ignore_regexes = [re.compile(regex) for regex in ignore_length_regex]
 
         for line_number, line in enumerate(file):
             line = spacing_helper.replace_tabs_with_spaces(line)
             if len(line) > max_line_length + 1:
-                if ignore_length_regex and ignore_regex.match(line):
+                if any(regex.match(line) for regex in ignore_regexes):
                     continue
 
                 yield Result.from_values(

--- a/bears/general/LineLengthBear.py
+++ b/bears/general/LineLengthBear.py
@@ -28,7 +28,7 @@ class LineLengthBear(LocalBear):
         for line_number, line in enumerate(file):
             line = spacing_helper.replace_tabs_with_spaces(line)
             if len(line) > max_line_length + 1:
-                if any(regex.match(line) for regex in ignore_regexes):
+                if any(regex.search(line) for regex in ignore_regexes):
                     continue
 
                 yield Result.from_values(

--- a/bears/tests/general/LineLengthBearTest.py
+++ b/bears/tests/general/LineLengthBearTest.py
@@ -22,4 +22,21 @@ LineLengthBear2Test = verify_local_bear(LineLengthBear,
                                         invalid_files=(["asdasd"],),
                                         settings={
                                             "max_line_length": "4",
-                                            "ignore_length_regex": "http://"})
+                                            "ignore_length_regex": "http://, "})
+
+LineLengthBear3Test = verify_local_bear(LineLengthBear,
+                                        valid_files=(test_file,
+                                                     ["hi there ftp://!"]),
+                                        invalid_files=(["asdasd"],),
+                                        settings={
+                                            "max_line_length": "4",
+                                            "ignore_length_regex": "ftp://, "})
+
+ineLengthBear4Test = verify_local_bear(LineLengthBear,
+                                       valid_files=(test_file,
+                                                    ["say hi.",
+                                                     "ftp://a.domain.de"]),
+                                       invalid_files=(["asdasd"],),
+                                       settings={
+                                            "max_line_length": "4",
+                                            "ignore_length_regex": "ftp://,hi"})


### PR DESCRIPTION
LineLengthBear will now search  the string anywhere for the given
regular expression.

Multiple regexes can now be used.

Fixes https://github.com/coala-analyzer/coala/issues/1554