### PR TITLE
codestyle: Use shlex.quote() to standardize code

### DIFF
--- a/bears/js/JSHintBear.py
+++ b/bears/js/JSHintBear.py
@@ -1,8 +1,8 @@
 import re
+import shlex
 
 from coalib.bearlib.abstractions.Lint import Lint
 from coalib.bears.LocalBear import LocalBear
-from coalib.misc.Shell import escape_path_argument
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 
 
@@ -29,6 +29,6 @@ class JSHintBear(LocalBear, Lint):
         self.arguments = '--verbose {filename}'
         if jshint_config:
             self.arguments += (" --config "
-                               + escape_path_argument(jshint_config))
+                               + shlex.quote(jshint_config))
 
         return self.lint(filename)

--- a/bears/perl/PerlCriticBear.py
+++ b/bears/perl/PerlCriticBear.py
@@ -1,8 +1,8 @@
 import re
+import shlex
 
 from coalib.bearlib.abstractions.Lint import Lint
 from coalib.bears.LocalBear import LocalBear
-from coalib.misc.Shell import escape_path_argument
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 
 
@@ -31,6 +31,6 @@ class PerlCriticBear(LocalBear, Lint):
         self.arguments = '--no-color --verbose "%l|%c|%s|%p|%m (%e)"'
         if perlcritic_config:
             self.arguments += (" --config "
-                               + escape_path_argument(perlcritic_config))
+                               + shlex.quote(perlcritic_config))
         self.arguments += " {filename}"
         return self.lint(filename)

--- a/bears/python/PyLintBear.py
+++ b/bears/python/PyLintBear.py
@@ -1,9 +1,9 @@
 import os
 import re
+import shlex
 
 from coalib.bearlib.abstractions.Lint import Lint
 from coalib.bears.LocalBear import LocalBear
-from coalib.misc.Shell import escape_path_argument
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 from coalib.settings.Setting import typed_list
 
@@ -49,7 +49,7 @@ class PyLintBear(LocalBear, Lint):
         if pylint_cli_options:
             self.arguments += " " + pylint_cli_options
         if pylint_rcfile:
-            self.arguments += " --rcfile=" + escape_path_argument(pylint_rcfile)
+            self.arguments += " --rcfile=" + shlex.quote(pylint_rcfile)
         else:
             self.arguments += " --rcfile=" + os.devnull
         self.arguments += " {filename}"

--- a/coalib/bearlib/abstractions/Lint.py
+++ b/coalib/bearlib/abstractions/Lint.py
@@ -2,9 +2,10 @@ import os
 import re
 import shutil
 import tempfile
+import shlex
 
 from coalib.bears.Bear import Bear
-from coalib.misc.Shell import escape_path_argument, run_shell_command
+from coalib.misc.Shell import run_shell_command
 from coalib.results.Diff import Diff
 from coalib.results.Result import Result
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
@@ -146,7 +147,7 @@ class Lint(Bear):
     def _create_command(self, **kwargs):
         command = self.executable + ' ' + self.arguments
         for key in ("filename", "config_file"):
-            kwargs[key] = escape_path_argument(kwargs.get(key, "") or "")
+            kwargs[key] = shlex.quote(kwargs.get(key, "") or "")
         return command.format(**kwargs)
 
     def __print_errors(self, errors):

--- a/coalib/misc/Shell.py
+++ b/coalib/misc/Shell.py
@@ -93,26 +93,3 @@ def prepare_string_argument(string, shell=get_shell_type()):
         return '"' + escape(string, '"') + '"'
     else:
         return string
-
-
-def escape_path_argument(path, shell=get_shell_type()):
-    """
-    Makes a raw path ready for using as parameter in a shell command (escapes
-    illegal characters, surrounds with quotes etc.).
-
-    :param path:  The path to make ready for shell.
-    :param shell: The shell platform to escape the path argument for. Possible
-                  values are "sh", "powershell", and "cmd" (others will be
-                  ignored and return the given path without modification).
-    :return:      The escaped path argument.
-    """
-    if shell == "cmd":
-        # If a quote (") occurs in path (which is illegal for NTFS file
-        # systems, but maybe for others), escape it by preceding it with
-        # a caret (^).
-        return '"' + escape(path, '"', '^') + '"'
-    elif shell == "sh":
-        return escape(path, " ")
-    else:
-        # Any other non-supported system doesn't get a path escape.
-        return path

--- a/coalib/tests/bearlib/abstractions/LintTest.py
+++ b/coalib/tests/bearlib/abstractions/LintTest.py
@@ -1,10 +1,10 @@
 import os
 import unittest
+import shlex
 
 from bears.c_languages.IndentBear import IndentBear
 from bears.tests.BearTestHelper import generate_skip_decorator
 from coalib.bearlib.abstractions.Lint import Lint
-from coalib.misc.Shell import escape_path_argument
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 from coalib.results.SourceRange import SourceRange
 from coalib.settings.Section import Section
@@ -102,7 +102,7 @@ class LintTest(unittest.TestCase):
 
         self.assertEqual(
             self.uut._create_command(config_file="configfile").strip(),
-            "echo -c " + escape_path_argument("configfile"))
+            "echo -c " + shlex.quote("configfile"))
 
     def test_config_file_generator(self):
         self.uut.executable = "echo"

--- a/coalib/tests/misc/ShellTest.py
+++ b/coalib/tests/misc/ShellTest.py
@@ -1,77 +1,11 @@
 import os
 import sys
 import unittest
+import shlex
 
 from coalib.misc.Shell import (
-    escape_path_argument, prepare_string_argument,
+    prepare_string_argument,
     run_interactive_shell_command, run_shell_command)
-
-
-class EscapePathArgumentTest(unittest.TestCase):
-
-    def test_escape_path_argument_sh(self):
-        _type = "sh"
-        self.assertEqual(
-            escape_path_argument("/home/usr/a-file", _type),
-            "/home/usr/a-file")
-        self.assertEqual(
-            escape_path_argument("/home/usr/a-dir/", _type),
-            "/home/usr/a-dir/")
-        self.assertEqual(
-            escape_path_argument("/home/us r/a-file with spaces.bla",
-                                 _type),
-            "/home/us\\ r/a-file\\ with\\ spaces.bla")
-        self.assertEqual(
-            escape_path_argument("/home/us r/a-dir with spaces/x/",
-                                 _type),
-            "/home/us\\ r/a-dir\\ with\\ spaces/x/")
-        self.assertEqual(
-            escape_path_argument(
-                "relative something/with cherries and/pickles.delicious",
-                _type),
-            "relative\\ something/with\\ cherries\\ and/pickles.delicious")
-
-    def test_escape_path_argument_cmd(self):
-        _type = "cmd"
-        self.assertEqual(
-            escape_path_argument("C:\\Windows\\has-a-weird-shell.txt", _type),
-            "\"C:\\Windows\\has-a-weird-shell.txt\"")
-        self.assertEqual(
-            escape_path_argument("C:\\Windows\\lolrofl\\dirs\\", _type),
-            "\"C:\\Windows\\lolrofl\\dirs\\\"")
-        self.assertEqual(
-            escape_path_argument("X:\\Users\\Maito Gai\\fi le.exe", _type),
-            "\"X:\\Users\\Maito Gai\\fi le.exe\"")
-        self.assertEqual(
-            escape_path_argument("X:\\Users\\Mai to Gai\\director y\\",
-                                 _type),
-            "\"X:\\Users\\Mai to Gai\\director y\\\"")
-        self.assertEqual(
-            escape_path_argument("X:\\Users\\Maito Gai\\\"seven-gates\".y",
-                                 _type),
-            "\"X:\\Users\\Maito Gai\\^\"seven-gates^\".y\"")
-        self.assertEqual(
-            escape_path_argument("System32\\my-custom relative tool\\",
-                                 _type),
-            "\"System32\\my-custom relative tool\\\"")
-        self.assertEqual(
-            escape_path_argument("System32\\illegal\" name \"\".curd", _type),
-            "\"System32\\illegal^\" name ^\"^\".curd\"")
-
-    def test_escape_path_argument_unsupported(self):
-        _type = "INVALID"
-        self.assertEqual(
-            escape_path_argument("/home/usr/a-file", _type),
-            "/home/usr/a-file")
-        self.assertEqual(
-            escape_path_argument("/home/us r/a-file with spaces.bla", _type),
-            "/home/us r/a-file with spaces.bla")
-        self.assertEqual(
-            escape_path_argument("|home|us r|a*dir with spaces|x|", _type),
-            "|home|us r|a*dir with spaces|x|")
-        self.assertEqual(
-            escape_path_argument("system|a|b|c?d", _type),
-            "system|a|b|c?d")
 
 
 class RunShellCommandTest(unittest.TestCase):
@@ -79,7 +13,7 @@ class RunShellCommandTest(unittest.TestCase):
     @staticmethod
     def construct_testscript_command(scriptname):
         return " ".join(
-            escape_path_argument(s) for s in (
+            shlex.quote(s) for s in (
                 sys.executable,
                 os.path.join(os.path.dirname(os.path.realpath(__file__)),
                              "run_shell_command_testfiles",


### PR DESCRIPTION
`shlex.quote()` is introduced in Python 3.3. This can, and should
replace `Shell.escape_path_argument()`, which is self-written.

Fixes https://github.com/coala-analyzer/coala/issues/1588