### PR TITLE
Sourceposition.py: Return relative paths

### DIFF
--- a/coalib/results/SourcePosition.py
+++ b/coalib/results/SourcePosition.py
@@ -24,8 +24,7 @@ class SourcePosition(TextPosition):
                             - line or columns are no integers.
         """
         TextPosition.__init__(self, line, column)
-
-        self._file = os.path.abspath(file)
+        self._file = os.path.relpath(file or os.curdir)
 
     @property
     def file(self):

--- a/coalib/tests/output/ConsoleInteractionTest.py
+++ b/coalib/tests/output/ConsoleInteractionTest.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from collections import OrderedDict
-from os.path import abspath, relpath
+from os.path import relpath
 
 from pyprint.ConsolePrinter import ConsolePrinter
 from pyprint.NullPrinter import NullPrinter
@@ -252,8 +252,8 @@ class ConsoleInteractionTest(unittest.TestCase):
                                         affected_code=affected_code),
                                  file_dict,
                                  color=True)
-            self.assertEqual(stdout.getvalue(),
-                             "\n"+relpath(some_file)+"\n")
+            self.assertIn(relpath(some_file),
+                          stdout.getvalue())
 
     def test_acquire_actions_and_apply(self):
         with make_temp() as testfile_path:
@@ -371,7 +371,7 @@ Project wide:
                                     "Trailing whitespace found",
                                     file="filename",
                                     line=2)],
-                {abspath("filename"): ["test line\n", "line 2\n", "line 3\n"]},
+                {relpath("filename"): ["test line\n", "line 2\n", "line 3\n"]},
                 {},
                 color=False)
             self.assertEqual("""\nfilename
@@ -389,7 +389,7 @@ Project wide:
                                     "Trailing whitespace found",
                                     file="filename",
                                     line=5)],
-                {abspath("filename"): ["test line\n",
+                {relpath("filename"): ["test line\n",
                                        "line 2\n",
                                        "line 3\n",
                                        "line 4\n",
@@ -415,7 +415,7 @@ Project wide:
                                               "Trailing whitespace found",
                                               file="file",
                                               line=2)],
-                          {abspath("file"): ["test line\n",
+                          {relpath("file"): ["test line\n",
                                              "line 2\n",
                                              "line 3\n",
                                              "line 4\n",
@@ -448,9 +448,9 @@ file
                 [Result("ClangCloneDetectionBear",
                         "Clone Found",
                         affected_code)],
-                {abspath("some_file"): ["line " + str(i + 1) + "\n"
+                {relpath("some_file"): ["line " + str(i + 1) + "\n"
                                         for i in range(10)],
-                 abspath("another_file"): ["line " + str(i + 1) + "\n"
+                 relpath("another_file"): ["line " + str(i + 1) + "\n"
                                            for i in range(10)]},
                 {},
                 color=False)
@@ -497,7 +497,7 @@ some_file
                 Section(""),
                 [Result.from_values("t", "msg", file="file", line=5),
                  Result.from_values("t", "msg", file="file", line=6)],
-                {abspath("file"): ["line " + str(i + 1) for i in range(5)]},
+                {relpath("file"): ["line " + str(i + 1) for i in range(5)]},
                 {},
                 color=False)
             self.assertEqual("\n"
@@ -518,7 +518,7 @@ some_file
                 self.log_printer,
                 Section(""),
                 [Result.from_values("t", "msg", file="file")],
-                {abspath("file"): []},
+                {relpath("file"): []},
                 {},
                 color=False)
             self.assertEqual(

--- a/coalib/tests/output/dbus/DbusDocumentTest.py
+++ b/coalib/tests/output/dbus/DbusDocumentTest.py
@@ -13,11 +13,11 @@ except ImportError as err:
 class DbusDocumentTest(unittest.TestCase):
 
     def setUp(self):
-        self.config_path = os.path.abspath(
+        self.config_path = os.path.relpath(
             os.path.join(os.path.dirname(__file__),
                          "dbus_test_files",
                          ".coafile"))
-        self.testcode_c_path = os.path.abspath(
+        self.testcode_c_path = os.path.relpath(
             os.path.join(os.path.dirname(__file__),
                          "dbus_test_files",
                          "testcode.c"))
@@ -28,14 +28,15 @@ class DbusDocumentTest(unittest.TestCase):
         self.assertEqual(uut.path, "")
 
         uut = DbusDocument(doc_id=1, path=test_file)
-        self.assertEqual(uut.path, os.path.abspath(test_file))
+        self.assertEqual(os.path.relpath(uut.path), os.path.relpath(test_file))
 
     def test_config(self):
         uut = DbusDocument(doc_id=1)
         self.assertEqual(uut.FindConfigFile(), "")
 
         uut.path = self.testcode_c_path
-        self.assertEqual(uut.FindConfigFile(), self.config_path)
+        self.assertEqual(os.path.relpath(
+            uut.FindConfigFile()), self.config_path)
 
         uut.SetConfigFile("config_file")
         self.assertEqual(uut.config_file, "config_file")

--- a/coalib/tests/output/dbus/DbusTest.py
+++ b/coalib/tests/output/dbus/DbusTest.py
@@ -42,11 +42,11 @@ mainloop.run()
 class DbusTest(unittest.TestCase):
 
     def setUp(self):
-        self.config_path = os.path.abspath(
+        self.config_path = os.path.relpath(
             os.path.join(os.path.dirname(__file__),
                          "dbus_test_files",
                          ".coafile"))
-        self.testcode_c_path = os.path.abspath(
+        self.testcode_c_path = os.path.relpath(
             os.path.join(os.path.dirname(__file__),
                          "dbus_test_files",
                          "testcode.c"))
@@ -92,7 +92,7 @@ class DbusTest(unittest.TestCase):
 
         config_file = self.document_object.FindConfigFile(
             dbus_interface="org.coala_analyzer.v1")
-        self.assertEqual(config_file, self.config_path)
+        self.assertEqual(os.path.relpath(config_file), self.config_path)
 
         analysis = self.document_object.Analyze(
             dbus_interface="org.coala_analyzer.v1")

--- a/coalib/tests/results/ResultFilterTest.py
+++ b/coalib/tests/results/ResultFilterTest.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from os.path import abspath
+from os.path import relpath
 
 from coalib.results.Diff import Diff
 from coalib.results.Result import RESULT_SEVERITY, Result
@@ -66,7 +66,7 @@ class ResultFilterTest(unittest.TestCase):
             severity=RESULT_SEVERITY.NORMAL,
             debug_msg="another debug message")
 
-        file_dict = {abspath("original"): []}
+        file_dict = {relpath("original"): []}
 
         self.assertEqual(sorted(filter_results(original_file_dict=file_dict,
                                                modified_file_dict=file_dict,
@@ -352,11 +352,11 @@ class ResultFilterTest(unittest.TestCase):
 
         with open(self.original_file_name, "r") as original_file:
             original_file_dict = {
-                abspath("file_name"): original_file.readlines()}
+                relpath("file_name"): original_file.readlines()}
 
             with open(self.modified_file_name, "r") as modified_file:
                 modified_file_dict = {
-                    abspath("file_name"): modified_file.readlines()}
+                    relpath("file_name"): modified_file.readlines()}
 
                 # 'TIS THE IMPORTANT PART
                 self.assertEqual(sorted(filter_results(original_file_dict,
@@ -371,7 +371,7 @@ class ResultFilterTest(unittest.TestCase):
         testfile_2_new = ['0\n', '1\n', '2\n']
         old_result = Result.from_values('origin', 'message', 'tf1', 1)
         new_result = Result.from_values('origin', 'message', 'tf1', 1)
-        tf1 = abspath('tf1')
+        tf1 = relpath('tf1')
         original_file_dict = {tf1: testfile_1, 'tf2': testfile_2}
         modified_file_dict = {tf1: testfile_1, 'tf2': testfile_2_new}
 
@@ -456,7 +456,7 @@ class ResultFilterTest(unittest.TestCase):
 
     def test_result_range_inline_overlap(self):
         test_file = ["123456789\n"]
-        test_file_dict = {abspath("test_file"): test_file}
+        test_file_dict = {relpath("test_file"): test_file}
 
         source_range1 = SourceRange.from_values("test_file", 1, 1, 1, 4)
         source_range2 = SourceRange.from_values("test_file", 1, 2, 1, 3)
@@ -468,14 +468,14 @@ class ResultFilterTest(unittest.TestCase):
 
         result_diff = remove_result_ranges_diffs(
             [test_result],
-            test_file_dict)[test_result][abspath("test_file")]
+            test_file_dict)[test_result][relpath("test_file")]
         expected_diff = Diff.from_string_arrays(test_file, ["789\n"])
 
         self.assertEqual(result_diff, expected_diff)
 
     def test_result_range_line_wise_overlap(self):
         test_file = ["11", "22", "33", "44", "55", "66"]
-        test_file_dict = {abspath("test_file"): test_file}
+        test_file_dict = {relpath("test_file"): test_file}
 
         source_range1 = SourceRange.from_values("test_file", 2, 2, 5, 1)
         source_range2 = SourceRange.from_values("test_file", 3, 1, 4, 1)
@@ -486,7 +486,7 @@ class ResultFilterTest(unittest.TestCase):
 
         result_diff = remove_result_ranges_diffs(
             [test_result],
-            test_file_dict)[test_result][abspath("test_file")]
+            test_file_dict)[test_result][relpath("test_file")]
         expected_diff = Diff.from_string_arrays(test_file,
                                                 ["11", "2", "5", "66"])
 
@@ -494,14 +494,14 @@ class ResultFilterTest(unittest.TestCase):
 
     def test_no_range(self):
         test_file = ["abc"]
-        test_file_dict = {abspath("test_file"): test_file}
+        test_file_dict = {relpath("test_file"): test_file}
 
         test_result = Result("origin",
                              "message")
 
         result_diff = remove_result_ranges_diffs(
             [test_result],
-            test_file_dict)[test_result][abspath("test_file")]
+            test_file_dict)[test_result][relpath("test_file")]
         expected_diff = Diff.from_string_arrays(test_file, ["abc"])
 
         self.assertEqual(result_diff, expected_diff)

--- a/coalib/tests/results/ResultTest.py
+++ b/coalib/tests/results/ResultTest.py
@@ -1,5 +1,5 @@
 import unittest
-from os.path import abspath
+from os.path import relpath
 
 from coalib.results.Diff import Diff
 from coalib.results.Result import RESULT_SEVERITY, Result
@@ -43,7 +43,7 @@ class ResultTest(unittest.TestCase):
         self.assertEqual(output, {"id": str(uut.id),
                                   "origin": "origin",
                                   "message": "msg",
-                                  "file": abspath("file"),
+                                  "file": relpath("file"),
                                   "line_nr": "2",
                                   "severity": "INFO",
                                   "debug_msg": "dbg"})

--- a/coalib/tests/results/result_actions/OpenEditorActionTest.py
+++ b/coalib/tests/results/result_actions/OpenEditorActionTest.py
@@ -35,6 +35,7 @@ class OpenEditorActionTest(unittest.TestCase):
         fbhandle, self.fb = tempfile.mkstemp()
         os.close(fbhandle)
         self.old_subprocess_call = subprocess.call
+        self.fa, self.fb = map(os.path.relpath, [self.fa, self.fb])
 
     def tearDown(self):
         os.remove(self.fa)
@@ -51,7 +52,6 @@ class OpenEditorActionTest(unittest.TestCase):
         # A patch that was applied for some reason to make things complicated
         diff_dict = {self.fb: Diff(file_dict[self.fb])}
         diff_dict[self.fb].change_line(3, "3\n", "3_changed\n")
-
         # File contents after the patch was applied, that's what's in the files
         current_file_dict = {
             filename: diff_dict[filename].modified
@@ -60,7 +60,6 @@ class OpenEditorActionTest(unittest.TestCase):
         for filename in current_file_dict:
             with open(filename, 'w') as handle:
                 handle.writelines(current_file_dict[filename])
-
         # End file contents after the patch and the OpenEditorAction was
         # applied
         expected_file_dict = {


### PR DESCRIPTION
This commit changes the path for affected files from absolute
to relative path w.r.t current directory path. This change
is essential for coala-html to work

Fixes https://github.com/coala-analyzer/coala/issues/1593