### PR TITLE
project: Replaced variables named as dummy with _

### DIFF
--- a/bears/c_languages/codeclone_detection/ClangCountingConditions.py
+++ b/bears/c_languages/codeclone_detection/ClangCountingConditions.py
@@ -67,7 +67,7 @@ def _stack_contains_kind(stack, kind):
     :param kind:  The kind of the cursor to search for.
     :return:      True if the kind was found.
     """
-    for elem, dummy in stack:
+    for elem, _ in stack:
         if elem.kind == kind:
             return True
 
@@ -171,7 +171,7 @@ def _get_positions_in_for_loop(stack):
     :return:       A list of semantic FOR_POSITION's within for loops.
     """
     results = []
-    for elem, dummy in stack:
+    for elem, _ in stack:
         if elem.kind == CursorKind.FOR_STMT:
             results.append(_get_position_in_for_tokens(
                 elem.get_tokens(),
@@ -212,7 +212,7 @@ def _stack_contains_operators(stack, operators):
     :param operators: A list of strings. E.g. ["+", "-"]
     :return:          True if the operator was found.
     """
-    for elem, dummy in stack:
+    for elem, _ in stack:
         if elem.kind in [CursorKind.BINARY_OPERATOR,
                          CursorKind.COMPOUND_ASSIGNMENT_OPERATOR]:
             operator = _get_binop_operator(elem)
@@ -287,7 +287,7 @@ def is_inc_or_dec(stack):
     """
     Returns true if the cursor on top is inc- or decremented.
     """
-    for elem, dummy in stack:
+    for elem, _ in stack:
         if elem.kind == CursorKind.UNARY_OPERATOR:
             for token in elem.get_tokens():
                 if token.spelling in ["--", "++"]:
@@ -334,7 +334,7 @@ def is_assignee(stack):
     Returns true if the cursor on top is assigned something.
     """
     cursor_pos = (stack[-1][0].extent.end.line, stack[-1][0].extent.end.column)
-    for elem, dummy in stack:
+    for elem, _ in stack:
         if (
                 elem.kind == CursorKind.BINARY_OPERATOR or
                 elem.kind == CursorKind.COMPOUND_ASSIGNMENT_OPERATOR):
@@ -356,7 +356,7 @@ def is_assigner(stack):
     """
     cursor_pos = (stack[-1][0].extent.start.line,
                   stack[-1][0].extent.start.column)
-    for elem, dummy in stack:
+    for elem, _ in stack:
         if (
                 elem.kind == CursorKind.BINARY_OPERATOR or
                 elem.kind == CursorKind.COMPOUND_ASSIGNMENT_OPERATOR):

--- a/coalib/collecting/Collectors.py
+++ b/coalib/collecting/Collectors.py
@@ -90,7 +90,7 @@ def collect_dirs(dir_paths, ignored_dir_paths=None):
     valid_dirs = list(filter(lambda fname: os.path.isdir(fname[0]),
                              icollect(dir_paths, ignored_dir_paths)))
     if valid_dirs:
-        collected_dirs, dummy = zip(*valid_dirs)
+        collected_dirs, _ = zip(*valid_dirs)
         return list(collected_dirs)
     else:
         return []

--- a/coalib/parsing/CliParsing.py
+++ b/coalib/parsing/CliParsing.py
@@ -79,10 +79,10 @@ def parse_custom_settings(sections,
     :param line_parser:          The LineParser to use.
     """
     for setting_definition in custom_settings_list:
-        (dummy,
+        (_,
          key_touples,
          value,
-         dummy) = line_parser.parse(setting_definition)
+         _) = line_parser.parse(setting_definition)
         for key_touple in key_touples:
             append_to_sections(sections,
                                key=key_touple[1],

--- a/coalib/settings/FunctionMetadata.py
+++ b/coalib/settings/FunctionMetadata.py
@@ -85,12 +85,12 @@ class FunctionMetadata:
         params = {}
 
         for param in self.non_optional_params:
-            dummy, annotation = self.non_optional_params[param]
+            _, annotation = self.non_optional_params[param]
             params[param] = self._get_param(param, section, annotation)
 
         for param in self.optional_params:
             if param in section:
-                dummy, annotation, dummy = self.optional_params[param]
+                _, annotation, _ = self.optional_params[param]
                 params[param] = self._get_param(param, section, annotation)
 
         return params

--- a/coalib/tests/settings/ConfigurationGatheringTest.py
+++ b/coalib/tests/settings/ConfigurationGatheringTest.py
@@ -243,7 +243,7 @@ class ConfigurationGatheringTest(unittest.TestCase):
         old_cwd = os.getcwd()
         try:
             os.chdir(child_dir)
-            sections, dummy, dummy, dummy = gather_configuration(
+            sections, _, _, _ = gather_configuration(
                 lambda *args: True,
                 self.log_printer,
                 arg_list=["--find-config"])
@@ -285,7 +285,7 @@ class ConfigurationGatheringTest(unittest.TestCase):
         os.path.isfile = old_isfile
 
     def test_autoapply_arg(self):
-        sections, dummy, dummy, dummy = gather_configuration(
+        sections, _, _, _ = gather_configuration(
             lambda *args: True,
             self.log_printer,
             autoapply=False,
@@ -294,7 +294,7 @@ class ConfigurationGatheringTest(unittest.TestCase):
         self.assertEqual(str(sections['default'].get('autoapply', None)),
                          'False')
 
-        sections, dummy, dummy, dummy = gather_configuration(
+        sections, _, _, _ = gather_configuration(
             lambda *args: True,
             self.log_printer,
             autoapply=True,


### PR DESCRIPTION
All the variables in the project which were named as dummy are replaced
with the _ (character underscore).

Fixes: https://github.com/coala-analyzer/coala/issues/1548