### PR TITLE
Shell.escape_path_argument: Use shlex.quote() for UNIX shells

### DIFF
--- a/coalib/misc/Shell.py
+++ b/coalib/misc/Shell.py
@@ -112,7 +112,7 @@ def escape_path_argument(path, shell=get_shell_type()):
         # a caret (^).
         return '"' + escape(path, '"', '^') + '"'
     elif shell == "sh":
-        return escape(path, " ")
+        return shlex.quote(path)
     else:
         # Any other non-supported system doesn't get a path escape.
         return path

--- a/coalib/tests/misc/ShellTest.py
+++ b/coalib/tests/misc/ShellTest.py
@@ -20,16 +20,16 @@ class EscapePathArgumentTest(unittest.TestCase):
         self.assertEqual(
             escape_path_argument("/home/us r/a-file with spaces.bla",
                                  _type),
-            "/home/us\\ r/a-file\\ with\\ spaces.bla")
+            "'/home/us r/a-file with spaces.bla'")
         self.assertEqual(
             escape_path_argument("/home/us r/a-dir with spaces/x/",
                                  _type),
-            "/home/us\\ r/a-dir\\ with\\ spaces/x/")
+            "'/home/us r/a-dir with spaces/x/'")
         self.assertEqual(
             escape_path_argument(
                 "relative something/with cherries and/pickles.delicious",
                 _type),
-            "relative\\ something/with\\ cherries\\ and/pickles.delicious")
+            "'relative something/with cherries and/pickles.delicious'")
 
     def test_escape_path_argument_cmd(self):
         _type = "cmd"


### PR DESCRIPTION
shlex.quote() is introduced in Python 3.3. This is to replace
`StringProcessing.escape` under `Shell.escape_path_argument` for UNIX
shells.

Fixes #1588 