### PR TITLE
Fix a few more things to get bear independency

### DIFF
--- a/coalib/tests/coalaCITest.py
+++ b/coalib/tests/coalaCITest.py
@@ -43,33 +43,33 @@ class coalaCITest(unittest.TestCase):
                          "own code.")
 
     def test_find_issues(self):
-        with bear_test_module():
-            with prepare_file(["#fixme"], None) as (lines, filename):
-                retval, output = execute_coala(
-                   coala_ci.main, "coala-ci",
-                   "-c", os.devnull,
-                   "-b", "LineCountTestBear",
-                   "-f", re.escape(filename))
-                self.assertIn("This file has 1 lines.",
-                              output,
-                              "The output should report count as 1 lines")
-                self.assertNotEqual(retval, 0,
-                                    "coala-ci was expected to return non-zero")
+        with bear_test_module(), \
+                prepare_file(["#fixme"], None) as (lines, filename):
+            retval, output = execute_coala(
+               coala_ci.main, "coala-ci",
+               "-c", os.devnull,
+               "-b", "LineCountTestBear",
+               "-f", re.escape(filename))
+            self.assertIn("This file has 1 lines.",
+                          output,
+                          "The output should report count as 1 lines")
+            self.assertNotEqual(retval, 0,
+                                "coala-ci was expected to return non-zero")
 
     def test_fix_patchable_issues(self):
-        with bear_test_module():
-            with prepare_file(["\t#include <a>"], None) as (lines, filename):
-                retval, output = execute_coala(
-                    coala_ci.main, "coala-ci",
-                    "-c", os.devnull,
-                    "-f", re.escape(filename),
-                    "-b", "SpaceConsistencyTestBear",
-                    "--settings", "autoapply=true", "use_spaces=True",
-                    "default_actions=SpaceConsistencyTestBear:ApplyPatchAction")
-                self.assertIn("Applied 'ApplyPatchAction'", output)
-                self.assertEqual(retval, 5,
-                                 "coala-ci must return exitcode 5 when it "
-                                 "autofixes the code.")
+        with bear_test_module(), \
+                prepare_file(["\t#include <a>"], None) as (lines, filename):
+            retval, output = execute_coala(
+                coala_ci.main, "coala-ci",
+                "-c", os.devnull,
+                "-f", re.escape(filename),
+                "-b", "SpaceConsistencyTestBear",
+                "--settings", "autoapply=true", "use_spaces=True",
+                "default_actions=SpaceConsistencyTestBear:ApplyPatchAction")
+            self.assertIn("Applied 'ApplyPatchAction'", output)
+            self.assertEqual(retval, 5,
+                             "coala-ci must return exitcode 5 when it "
+                             "autofixes the code.")
 
     def test_tagging(self):
         log_printer = LogPrinter(NullPrinter())

--- a/coalib/tests/coalaFormatTest.py
+++ b/coalib/tests/coalaFormatTest.py
@@ -5,7 +5,7 @@ import unittest
 
 from coalib import coala_format
 from coalib.misc.ContextManagers import prepare_file
-from coalib.tests.TestUtilities import execute_coala
+from coalib.tests.TestUtilities import bear_test_module, execute_coala
 
 
 class coalaFormatTest(unittest.TestCase):
@@ -17,18 +17,15 @@ class coalaFormatTest(unittest.TestCase):
         sys.argv = self.old_argv
 
     def test_line_count(self):
-        with prepare_file(["#fixme"], None) as (lines, filename):
-            bear = "LineCountBear"
-            retval, output = execute_coala(
-                             coala_format.main,
-                            "coala-format", "-c", os.devnull,
-                            "--settings", "files=" + re.escape(filename),
-                            "bears=" + bear)
-            self.assertRegex(output,
-                             r'msg:This file has [0-9]+ lines.',
-                             "coala-format output for line count should"
-                             " not be empty")
-            self.assertEqual(retval,
-                             1,
+        with bear_test_module(), \
+                prepare_file(["#fixme"], None) as (lines, filename):
+            retval, output = execute_coala(coala_format.main, "coala-format",
+                                           "-c", os.devnull,
+                                           "-f", re.escape(filename),
+                                           "-b", "LineCountTestBear")
+            self.assertRegex(output, r'msg:This file has [0-9]+ lines.',
+                             "coala-format output for line count should "
+                             "not be empty")
+            self.assertEqual(retval, 1,
                              "coala-format must return exitcode 1 when it "
                              "yields results")

--- a/coalib/tests/coalaJSONTest.py
+++ b/coalib/tests/coalaJSONTest.py
@@ -6,7 +6,7 @@ import unittest
 
 from coalib import coala_json
 from coalib.misc.ContextManagers import prepare_file
-from coalib.tests.TestUtilities import execute_coala
+from coalib.tests.TestUtilities import bear_test_module, execute_coala
 
 
 class coalaJSONTest(unittest.TestCase):
@@ -26,32 +26,30 @@ class coalaJSONTest(unittest.TestCase):
             "The requested coafile '.*' does not exist.")
 
     def test_find_issues(self):
-        with prepare_file(["#todo this is todo"], None) as (lines, filename):
-            bear = "KeywordBear"
-            retval, output = execute_coala(coala_json.main, "coala-json", "-c",
-                                           os.devnull, "-S",
-                                           "ci_keywords=#TODO",
-                                           "cs_keywords=#todo",
-                                           "bears=" + bear,
+        with bear_test_module(), \
+                prepare_file(["#fixme"], None) as (lines, filename):
+            retval, output = execute_coala(coala_json.main, "coala-json",
+                                           "-c", os.devnull,
+                                           "-b", "LineCountTestBear",
                                            "-f", re.escape(filename))
             output = json.loads(output)
             self.assertEqual(output["results"]["default"][0]["message"],
-                             "The line contains the keyword `#todo`.",
-                             "coala-json output should match the keyword #todo")
-            self.assertNotEqual(retval,
-                                0, "coala-json must return nonzero when "
-                                "matching `#todo` keyword")
+                             "This file has 1 lines.")
+            self.assertNotEqual(retval, 0,
+                                "coala-json must return nonzero when "
+                                "results found")
 
     def test_fail_acquire_settings(self):
-        retval, output = execute_coala(
-            coala_json.main, 'coala-json', '-b',
-            'SpaceConsistencyBear', '-c', os.devnull)
-        output = json.loads(output)
-        found = False
-        for msg in output["logs"]:
-            if "During execution, we found that some" in msg["message"]:
-                found = True
-        self.assertTrue(found)
+        with bear_test_module():
+            retval, output = execute_coala(coala_json.main, 'coala-json',
+                                           '-c', os.devnull,
+                                           '-b', 'SpaceConsistencyTestBear')
+            output = json.loads(output)
+            found = False
+            for msg in output["logs"]:
+                if "During execution, we found that some" in msg["message"]:
+                    found = True
+            self.assertTrue(found, "Missing settings not logged")
 
     def test_version(self):
         with self.assertRaises(SystemExit):

--- a/coalib/tests/coalaTest.py
+++ b/coalib/tests/coalaTest.py
@@ -19,13 +19,13 @@ class coalaTest(unittest.TestCase):
         sys.argv = self.old_argv
 
     def test_coala(self):
-        with bear_test_module():
-            with prepare_file(["#fixme"], None) as (lines, filename):
-                retval, output = execute_coala(
-                                 coala.main,
-                                "coala", "-c", os.devnull,
-                                "-f", re.escape(filename),
-                                "-b", "LineCountTestBear")
+        with bear_test_module(), \
+                prepare_file(["#fixme"], None) as (lines, filename):
+            retval, output = execute_coala(
+                             coala.main,
+                            "coala", "-c", os.devnull,
+                            "-f", re.escape(filename),
+                            "-b", "LineCountTestBear")
             self.assertIn("This file has 1 lines.",
                           output,
                           "The output should report count as 1 lines")


### PR DESCRIPTION
Earlier I had used `git grep "from bears"` to check if I had missed anything.
The integration tests do not need to import bears, so this removes the bears dependency from them