### PR TITLE
Git_Hooks.rst: Fix typos in doc

### DIFF
--- a/docs/Users/Git_Hooks.rst
+++ b/docs/Users/Git_Hooks.rst
@@ -40,7 +40,7 @@ coala to not apply any patch by itself. Or you can run specific sections with
     `*.orig` to your .gitignore. coala creates these files while applying
     patches and they could be erroneously added to your commit.
 
-THis file needs to be executable. If it is not (or if you aren't sure), you
+This file needs to be executable. If it is not (or if you aren't sure), you
 can make it executable by:
 
 .. code:: bash


### PR DESCRIPTION
In the docs THis is changed to This

Fixes https://github.com/coala-analyzer/coala/issues/1535