### PR TITLE
Lint: Save important debug info to self

### DIFF
--- a/coalib/bearlib/abstractions/Lint.py
+++ b/coalib/bearlib/abstractions/Lint.py
@@ -97,18 +97,19 @@ class Lint(Bear):
                 (not self.use_stdin and filename is not None))
 
         config_file = self.generate_config_file()
-        command = self._create_command(filename=filename,
-                                       config_file=config_file)
+        self.command = self._create_command(filename=filename,
+                                            config_file=config_file)
 
         stdin_input = "".join(file) if self.use_stdin else None
-        stdout_output, stderr_output = run_shell_command(command,
+        stdout_output, stderr_output = run_shell_command(self.command,
                                                          stdin=stdin_input)
-        stdout_output = tuple(stdout_output.splitlines(keepends=True))
-        stderr_output = tuple(stderr_output.splitlines(keepends=True))
-        results_output = stderr_output if self.use_stderr else stdout_output
+        self.stdout_output = tuple(stdout_output.splitlines(keepends=True))
+        self.stderr_output = tuple(stderr_output.splitlines(keepends=True))
+        results_output = (self.stderr_output if self.use_stderr
+                          else self.stdout_output)
         results = self.process_output(results_output, filename, file)
         if not self.use_stderr:
-            self._print_errors(stderr_output)
+            self._print_errors(self.stderr_output)
 
         if config_file:
             os.remove(config_file)


### PR DESCRIPTION
When Lint tests are happening, we need better data to be able to
debug things.
One possibility is to use DEBUG log_messages, but this would give
a lot of data when `-L DEBUG` is used in the cmdline. Hence, we
simply save these variables to `self` so that LocalBearTestHelper
can handle it in a better way.

Related to https://github.com/coala-analyzer/coala-bears/issues/72