### PR TITLE
Globbing: Add escape function for globs

### DIFF
--- a/coalib/coala_delete_orig.py
+++ b/coalib/coala_delete_orig.py
@@ -6,6 +6,7 @@ from coalib.output.printers.LogPrinter import LogPrinter
 from coalib.parsing import Globbing
 from coalib.settings.ConfigurationGathering import get_config_directory
 from coalib.settings.Section import Section
+from coalib.parsing.Globbing import glob_escape
 
 
 def main(log_printer=None, section: Section=None):
@@ -15,8 +16,9 @@ def main(log_printer=None, section: Section=None):
     if start_path is None:
         return 255
 
-    orig_files = Globbing.glob(os.path.abspath(
-        os.path.join(start_path, '**', '*.orig')))
+    # start_path may have unintended glob characters
+    orig_files = Globbing.glob(os.path.join(
+        glob_escape(start_path), '**', '*.orig'))
 
     not_deleted = 0
     for ofile in orig_files:

--- a/coalib/collecting/Collectors.py
+++ b/coalib/collecting/Collectors.py
@@ -6,7 +6,7 @@ from coalib.bears.BEAR_KIND import BEAR_KIND
 from coalib.collecting.Importers import iimport_objects
 from coalib.misc.Decorators import yield_once
 from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
-from coalib.parsing.Globbing import fnmatch, iglob
+from coalib.parsing.Globbing import fnmatch, iglob, glob_escape
 
 
 def _get_kind(bear_class):
@@ -110,6 +110,9 @@ def icollect_bears(bear_dirs, bear_globs, kinds, log_printer):
     """
     for bear_dir, dir_glob in filter(lambda x: os.path.isdir(x[0]),
                                      icollect(bear_dirs)):
+        # Since we get a real directory here and since we
+        # pass this later to iglob, we need to escape this.
+        bear_dir = glob_escape(bear_dir)
         for bear_glob in bear_globs:
             for matching_file in iglob(
                     os.path.join(bear_dir, bear_glob + '.py')):

--- a/coalib/misc/Constants.py
+++ b/coalib/misc/Constants.py
@@ -71,3 +71,5 @@ with open(VERSION_FILE, 'r') as ver:
 BUS_NAME = "org.coala_analyzer.v1"
 
 TAGS_DIR = appdirs.user_data_dir('coala', version=VERSION)
+
+GLOBBING_SPECIAL_CHARS = "()[]|?*"

--- a/coalib/output/dbus/DbusDocument.py
+++ b/coalib/output/dbus/DbusDocument.py
@@ -10,7 +10,7 @@ from coalib.processes.Processing import execute_section
 from coalib.results.HiddenResult import HiddenResult
 from coalib.settings.ConfigurationGathering import (
     find_user_config, gather_configuration)
-from coalib.settings.Setting import path_list
+from coalib.settings.Setting import glob_list
 
 
 class DbusDocument(dbus.service.Object):
@@ -124,7 +124,7 @@ class DbusDocument(dbus.service.Object):
                     continue
 
                 if any([fnmatch(self.path, file_pattern)
-                        for file_pattern in path_list(section["files"])]):
+                        for file_pattern in glob_list(section["files"])]):
 
                     section["files"].value = self.path
                     section_result = execute_section(

--- a/coalib/parsing/Globbing.py
+++ b/coalib/parsing/Globbing.py
@@ -3,6 +3,7 @@ import platform
 import re
 
 from coalib.misc.Decorators import yield_once
+from coalib.misc.Constants import GLOBBING_SPECIAL_CHARS
 
 
 def _end_of_set_index(string, start_index):
@@ -27,6 +28,26 @@ def _end_of_set_index(string, start_index):
         closing_index += 1
 
     return closing_index
+
+
+def glob_escape(input_string):
+    """
+    Escapes the given string with ``[c]`` pattern. Examples:
+
+    >>> from coalib.parsing.Globbing import glob_escape
+    >>> glob_escape('test (1)')
+    'test [(]1[)]'
+    >>> glob_escape('test folder?')
+    'test folder[?]'
+    >>> glob_escape('test*folder')
+    'test[*]folder'
+
+    :param input_string: String that is to be escaped with ``[ ]``.
+    :return:             Escaped string in which all the special glob characters
+                         ``()[]|?*`` are escaped.
+    """
+    return re.sub("(?P<char>[" + re.escape(GLOBBING_SPECIAL_CHARS) + "])",
+                  "[\\g<char>]", input_string)
 
 
 def _position_is_bracketed(string, position):

--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -19,7 +19,7 @@ from coalib.results.result_actions.PrintDebugMessageAction import (
 from coalib.results.result_actions.ShowPatchAction import ShowPatchAction
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 from coalib.results.SourceRange import SourceRange
-from coalib.settings.Setting import path_list
+from coalib.settings.Setting import glob_list
 from coalib.parsing.Globbing import fnmatch
 
 ACTIONS = [ApplyPatchAction,
@@ -335,10 +335,10 @@ def instantiate_processes(section,
                              the same for each object.
     """
     filename_list = collect_files(
-        path_list(section.get('files', "")),
+        glob_list(section.get('files', "")),
         log_printer,
-        ignored_file_paths=path_list(section.get('ignore', "")),
-        limit_file_paths=path_list(section.get('limit_files', "")))
+        ignored_file_paths=glob_list(section.get('ignore', "")),
+        limit_file_paths=glob_list(section.get('limit_files', "")))
     file_dict = get_file_dict(filename_list, log_printer)
 
     manager = multiprocessing.Manager()

--- a/coalib/settings/Section.py
+++ b/coalib/settings/Section.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from coalib.collecting.Collectors import collect_registered_bears_dirs
 from coalib.misc.Decorators import enforce_signature, generate_repr
 from coalib.misc.DictUtilities import update_ordered_dict_key
-from coalib.settings.Setting import Setting, path_list
+from coalib.settings.Setting import Setting, glob_list
 
 
 def append_to_sections(sections,
@@ -62,7 +62,7 @@ class Section:
         self.contents = OrderedDict()
 
     def bear_dirs(self):
-        bear_dirs = path_list(self.get("bear_dirs", ""))
+        bear_dirs = glob_list(self.get("bear_dirs", ""))
         for bear_dir in bear_dirs:
             sys.path.append(bear_dir)
         bear_dirs = [

--- a/coalib/settings/Setting.py
+++ b/coalib/settings/Setting.py
@@ -113,7 +113,7 @@ class Setting(StringConverter):
                                            last part will be stripped of. If
                                            you want to specify a directory as
                                            origin be sure to end it with a
-                                           directory seperator.
+                                           directory separator.
         :param strip_whitespaces:          Whether to strip whitespaces from
                                            the value or not
         :param list_delimiters:            Delimiters for list conversion

--- a/coalib/settings/Setting.py
+++ b/coalib/settings/Setting.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 
 from coalib.misc.Decorators import generate_repr
 from coalib.misc.StringConverter import StringConverter
+from coalib.parsing.Globbing import glob_escape
 
 
 def path(obj, *args, **kwargs):
@@ -15,6 +16,29 @@ def path_list(obj, *args, **kwargs):
 
 def url(obj, *args, **kwargs):
     return obj.__url__(*args, **kwargs)
+
+
+def glob(obj, *args, **kwargs):
+    """
+    Creates a path in which all special glob characters in all the
+    parent directories in the given setting are properly escaped.
+
+    :param obj: The ``Setting`` object from which the key is obtained.
+    :return:    Returns a path in which special glob characters are escaped.
+    """
+    return obj.__glob__(*args, **kwargs)
+
+
+def glob_list(obj, *args, **kwargs):
+    """
+    Creates a list of paths in which all special glob characters in all the
+    parent directories of all paths in the given setting are properly escaped.
+
+    :param obj: The ``Setting`` object from which the key is obtained.
+    :return:    Returns a list of paths in which special glob characters are
+                escaped.
+    """
+    return obj.__glob_list__(*args, **kwargs)
 
 
 def typed_list(conversion_func):
@@ -112,20 +136,23 @@ class Setting(StringConverter):
         self.key = key
         self.origin = str(origin)
 
-    def __path__(self, origin=None):
+    def __path__(self, origin=None, glob_escape_origin=False):
         """
         Determines the path of this setting.
 
         Note: You can also use this function on strings, in that case the
         origin argument will be taken in every case.
 
-        :param origin:      the origin file to take if no origin is specified
-                            for the given setting. If you want to provide a
-                            directory, make sure it ends with a directory
-                            seperator.
-        :return:            An absolute path.
-        :raises ValueError: If no origin is specified in the setting nor the
-                            given origin parameter.
+        :param origin:             The origin file to take if no origin is
+                                   specified for the given setting. If you
+                                   want to provide a directory, make sure it
+                                   ends with a directory separator.
+        :param glob_escape_origin: When this is set to true, the origin of
+                                   this setting will be escaped with
+                                   ``glob_escape``.
+        :return:                   An absolute path.
+        :raises ValueError:        If no origin is specified in the setting
+                                   nor the given origin parameter.
         """
         strrep = str(self).strip()
         if os.path.isabs(strrep):
@@ -137,7 +164,30 @@ class Setting(StringConverter):
         if origin is None:
             raise ValueError("Cannot determine path without origin.")
 
-        return os.path.abspath(os.path.join(os.path.dirname(origin), strrep))
+        # We need to get full path before escaping since the full path
+        # may introduce unintended glob characters
+        origin = os.path.abspath(os.path.dirname(origin))
+
+        if glob_escape_origin:
+            origin = glob_escape(origin)
+
+        return os.path.normpath(os.path.join(origin, strrep))
+
+    def __glob__(self, origin=None):
+        """
+        Determines the path of this setting with proper escaping of its
+        parent directories.
+
+        :param origin:      The origin file to take if no origin is specified
+                            for the given setting. If you want to provide a
+                            directory, make sure it ends with a directory
+                            separator.
+        :return:            An absolute path in which the parent directories
+                            are escaped.
+        :raises ValueError: If no origin is specified in the setting nor the
+                            given origin parameter.
+        """
+        return Setting.__path__(self, origin, glob_escape_origin=True)
 
     def __path_list__(self):
         """
@@ -147,6 +197,16 @@ class Setting(StringConverter):
         :return: A list of absolute paths.
         """
         return [Setting.__path__(elem, self.origin) for elem in self]
+
+    def __glob_list__(self):
+        """
+        Splits the value into a list and creates a path out of each item in
+        which the special glob characters in origin are escaped.
+
+        :return: A list of absolute paths in which the special characters in
+                 the parent directories of the setting are escaped.
+        """
+        return [Setting.__glob__(elem, self.origin) for elem in self]
 
     @property
     def key(self):

--- a/docs/Users/Glob_Patterns.rst
+++ b/docs/Users/Glob_Patterns.rst
@@ -18,30 +18,30 @@ Syntax
 
 The special characters used in shell-style wildcards are:
 
-+-----------------+-----------------------------------------------------------+
-| PATTERN         | MEANING                                                   |
-+=================+===========================================================+
-| '[seq]'         | Matches any character in seq. Cannot be empty. Any special|
-|                 | character looses its special meaning in a set.            |
-+-----------------+-----------------------------------------------------------+
-| '[!seq]'        | Matches any character not in seq. Cannot be empty. Any    |
-|                 | special character looses its special meaning in a set.    |
-+-----------------+-----------------------------------------------------------+
-| '(seq_a|seq_b)' | Matches either sequence_a or sequence_b as a whole. More  |
-|                 | than two or just one sequence can be given.               |
-+-----------------+-----------------------------------------------------------+
-| '?'             | Matches any single character.                             |
-+-----------------+-----------------------------------------------------------+
-| '*'             | Matches everything but the directory separator            |
-+-----------------+-----------------------------------------------------------+
-| '**'            | Matches everything.                                       |
-+-----------------+-----------------------------------------------------------+
++-------------------+---------------------------------------------------------+
+| PATTERN           | MEANING                                                 |
++===================+=========================================================+
+| ``[seq]``         | Matches any character in seq. Cannot be empty. Any      |
+|                   | special character looses its special meaning in a set.  |
++-------------------+---------------------------------------------------------+
+| ``[!seq]``        | Matches any character not in seq. Cannot be empty. Any  |
+|                   | special character looses its special meaning in a set.  |
++-------------------+---------------------------------------------------------+
+| ``(seq_a|seq_b)`` | Matches either sequence_a or sequence_b as a whole. More|
+|                   | than two or just one sequence can be given.             |
++-------------------+---------------------------------------------------------+
+| ``?``             | Matches any single character.                           |
++-------------------+---------------------------------------------------------+
+| ``*``             | Matches everything but the directory separator.         |
++-------------------+---------------------------------------------------------+
+| ``**``            | Matches everything.                                     |
++-------------------+---------------------------------------------------------+
 
 Examples
 --------
 
-'[seq]'
-~~~~~~~
+``[seq]``
+~~~~~~~~~
 
     Matches any character in seq. Cannot be empty. Any special character
     looses its special meaning in a set.
@@ -73,8 +73,8 @@ brackets have to be placed at the first position.
     >>> fnmatch("a[]a", "a[]a")
     True
 
-'[!seq]'
-~~~~~~~~
+``[!seq]``
+~~~~~~~~~~
 
     Matches any character not in seq. Cannot be empty. Any special
     character looses its special meaning in a set.
@@ -96,15 +96,15 @@ brackets have to be placed at the first position.
     >>> fnmatch("a[!]a", "a[!]a")
     True
 
-'(seq\_a\|seq\_b)'
-~~~~~~~~~~~~~~~~~~
+``(seq\_a\|seq\_b)``
+~~~~~~~~~~~~~~~~~~~~
 
     Matches either sequence\_a or sequence\_b as a whole. More than two
     or just one sequence can be given.
 
 Parentheses cannot be part of an alternative, unless they are escaped by
 brackets. Parentheses that have no match are ignored as well as
-'\|'-separators that are not inside matching parentheses
+``|``-separators that are not inside matching parentheses.
 
 ::
 
@@ -135,8 +135,8 @@ brackets. Parentheses that have no match are ignored as well as
     >>> fnmatch("", "(abc|)")
     True
 
-'?'
-~~~
+``?``
+~~~~~
 
     Matches any single character.
 
@@ -155,15 +155,15 @@ brackets. Parentheses that have no match are ignored as well as
     >>> fnmatch("ac", "a?c")
     False
 
-'\*'
-~~~~
+``\*``
+~~~~~~
 
-    Matches everything but the directory separator
+    Matches everything but the directory separator.
 
 .. note::
 
-    The directory separator is platform specific. '/' is never
-    matched by '\*'. '\\' is matched on Linux, but not on Windows.
+    The directory separator is platform specific. ``/`` is never
+    matched by ``\*``. ``\\`` is matched on Linux, but not on Windows.
 
 ::
 
@@ -178,8 +178,8 @@ brackets. Parentheses that have no match are ignored as well as
     >>> fnmatch("ac", "a*c")
     True
 
-'\*\*'
-~~~~~~
+``\*\*``
+~~~~~~~~
 
     Matches everything.
 

--- a/docs/Users/Glob_Patterns.rst
+++ b/docs/Users/Glob_Patterns.rst
@@ -6,6 +6,13 @@ input of multiple files without requiring a large number of filenames,
 coala supports a number of wildcards. These are based on the unix-style
 glob syntax and they are *not* the same as regular expressions.
 
+.. note::
+
+    Any glob that does not start with a ``/`` in Linux or a drive letter
+    ``X:`` in Windows will be interpreted as a relative path. Please use comma
+    separated values instead of absolute path globs that start with a
+    glob expression.
+
 Syntax
 ------
 

--- a/tests/parsing/GlobbingTest.py
+++ b/tests/parsing/GlobbingTest.py
@@ -18,7 +18,8 @@ import os
 import unittest
 
 from coalib.parsing.Globbing import (
-    _iter_alternatives, _iter_choices, _position_is_bracketed, fnmatch, glob)
+    _iter_alternatives, _iter_choices, _position_is_bracketed, fnmatch, glob,
+    glob_escape)
 
 
 class TestFiles:
@@ -98,6 +99,35 @@ class GlobbingHelperFunctionsTest(unittest.TestCase):
         for pattern, alternatives in pattern_alternatives_dict.items():
             self.assertEqual(sorted(list(_iter_alternatives(pattern))),
                              sorted(alternatives))
+
+
+class GlobEscapeTest(unittest.TestCase):
+
+    def test_glob_escape(self):
+        input_strings = [
+            "test",
+            "test[",
+            "test []",
+            "test [[]",
+            "test ]] str [",
+            "test[][]",
+            "test(",
+            "test)",
+            "test()",
+            "test (1)"]
+        output_strings = [
+            "test",
+            "test[[]",
+            "test [[][]]",
+            "test [[][[][]]",
+            "test []][]] str [[]",
+            "test[[][]][[][]]",
+            "test[(]",
+            "test[)]",
+            "test[(][)]",
+            "test [(]1[)]"]
+        for unescaped_str, escaped_str in zip(input_strings, output_strings):
+            self.assertEqual(glob_escape(unescaped_str), escaped_str)
 
 
 class FnmatchTest(unittest.TestCase):

--- a/tests/settings/SettingTest.py
+++ b/tests/settings/SettingTest.py
@@ -40,7 +40,7 @@ class SettingTest(unittest.TestCase):
         abspath = os.path.abspath(".")
         # Need to escape backslashes since we use list conversion
         self.uut = Setting("key", "., " + abspath.replace("\\", "\\\\"),
-                           origin="test" + os.path.sep + "somefile")
+                           origin=os.path.join("test", "somefile"))
         self.assertEqual(path_list(self.uut),
                          [os.path.abspath(os.path.join("test", ".")), abspath])
 

--- a/tests/settings/SettingTest.py
+++ b/tests/settings/SettingTest.py
@@ -4,7 +4,9 @@ import unittest
 from collections import OrderedDict
 
 from coalib.settings.Setting import (
-    Setting, path, path_list, url, typed_dict, typed_list, typed_ordered_dict)
+    Setting, path, path_list, url, typed_dict, typed_list, typed_ordered_dict,
+    glob, glob_list)
+from coalib.parsing.Globbing import glob_escape
 
 
 class SettingTest(unittest.TestCase):
@@ -28,6 +30,12 @@ class SettingTest(unittest.TestCase):
                               origin="test" + os.path.sep),
                          os.path.abspath(os.path.join("test", "22")))
 
+    def test_glob(self):
+        self.uut = Setting("key", ".",
+                           origin=os.path.join("test (1)", "somefile"))
+        self.assertEqual(glob(self.uut),
+                         glob_escape(os.path.abspath("test (1)")))
+
     def test_path_list(self):
         abspath = os.path.abspath(".")
         # Need to escape backslashes since we use list conversion
@@ -43,6 +51,16 @@ class SettingTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             uut = Setting("key", "abc")
             url(uut)
+
+    def test_glob_list(self):
+        abspath = glob_escape(os.path.abspath("."))
+        # Need to escape backslashes since we use list conversion
+        self.uut = Setting("key", "., " + abspath.replace("\\", "\\\\"),
+                           origin=os.path.join("test (1)", "somefile"))
+        self.assertEqual(
+            glob_list(self.uut),
+            [glob_escape(os.path.abspath(os.path.join("test (1)", "."))),
+             abspath])
 
     def test_typed_list(self):
         self.uut = Setting("key", "1, 2, 3")


### PR DESCRIPTION
When the coala directory's full path has brackets, the whole system breaks
because it is interpreted as alternatives. To fix this, the brackets are
escaped before use and then unescaped, leaving all functionality intact.

Fixes https://github.com/coala-analyzer/coala/issues/1613