### PR TITLE
Sourceposition.py: Return relative paths

### DIFF
--- a/coalib/coala_json.py
+++ b/coalib/coala_json.py
@@ -14,7 +14,7 @@
 import json
 
 from coalib.coala_main import run_coala
-from coalib.output.JSONEncoder import JSONEncoder
+from coalib.output.JSONEncoder import create_json_encoder
 from coalib.output.printers.ListLogPrinter import ListLogPrinter
 from coalib.parsing.DefaultArgParser import default_arg_parser
 
@@ -33,7 +33,7 @@ def main():
     retval = {"results": results}
     if not args.text_logs:
         retval["logs"] = log_printer.logs
-
+    JSONEncoder = create_json_encoder(use_relpath=args.relpath)
     if args.output:
         filename = str(args.output)
         with open(filename, 'w+') as fp:

--- a/coalib/output/JSONEncoder.py
+++ b/coalib/output/JSONEncoder.py
@@ -3,21 +3,32 @@ import json
 from datetime import datetime
 
 from coalib.misc.Decorators import get_public_members
+from coalib.settings.FunctionMetadata import FunctionMetadata
 
 
-class JSONEncoder(json.JSONEncoder):
+def create_json_encoder(**kwargs):
+    class JSONEncoder(json.JSONEncoder):
 
-    def default(self, obj):
-        if hasattr(obj, "__json__"):
-            return obj.__json__()
-        elif isinstance(obj, collections.Iterable):
-            return list(obj)
-        elif isinstance(obj, datetime):
-            return obj.isoformat()
-        elif hasattr(obj, "__getitem__") and hasattr(obj, "keys"):
-            return dict(obj)
-        elif hasattr(obj, "__dict__"):
-            return {member: getattr(obj, member)
-                    for member in get_public_members(obj)}
+        @classmethod
+        def _filter_params(cls, op, nop):
+            params = set(op) | set(nop)
+            return {key: kwargs[key] for key in set(kwargs) & (params)}
 
-        return json.JSONEncoder.default(self, obj)
+        def default(self, obj):
+            if hasattr(obj, "__json__"):
+                fdata = FunctionMetadata.from_function(obj.__json__)
+                params = self._filter_params(
+                    fdata.optional_params, fdata.non_optional_params)
+                return obj.__json__(**params)
+            elif isinstance(obj, collections.Iterable):
+                return list(obj)
+            elif isinstance(obj, datetime):
+                return obj.isoformat()
+            elif hasattr(obj, "__getitem__") and hasattr(obj, "keys"):
+                return dict(obj)
+            elif hasattr(obj, "__dict__"):
+                return {member: getattr(obj, member)
+                        for member in get_public_members(obj)}
+
+            return json.JSONEncoder.default(self, obj)
+    return JSONEncoder

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -170,5 +170,9 @@ def default_arg_parser(formatter_class=None):
                             const=True,
                             help="Deactivate creation of .orig files,"
                                  ".orig backup files before applying patches")
+    arg_parser.add_argument('-r',
+                            '--relpath',
+                            action='store_true',
+                            help="return relative paths for files")
 
     return arg_parser

--- a/coalib/results/Result.py
+++ b/coalib/results/Result.py
@@ -2,7 +2,7 @@ import uuid
 from os.path import relpath
 
 from coalib.misc.Decorators import (
-    enforce_signature, generate_ordering, generate_repr)
+    enforce_signature, generate_ordering, generate_repr, get_public_members)
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 from coalib.results.SourceRange import SourceRange
 
@@ -201,3 +201,10 @@ class Result:
 
         return ', '.join(repr(relpath(range_path))
                          for range_path in sorted(range_paths))
+
+    def __json__(self, use_relpath=False):
+        _dict = get_public_members(self)
+        if use_relpath and _dict['diffs']:
+            _dict['diffs'] = {relpath(file): diff
+                              for file, diff in _dict['diffs'].items()}
+        return _dict

--- a/coalib/results/SourcePosition.py
+++ b/coalib/results/SourcePosition.py
@@ -1,7 +1,7 @@
-import os
+from os.path import relpath, abspath
 
 from coalib.misc.Decorators import (
-    enforce_signature, generate_ordering, generate_repr)
+    enforce_signature, generate_ordering, generate_repr, get_public_members)
 from coalib.results.TextPosition import TextPosition
 
 
@@ -25,8 +25,14 @@ class SourcePosition(TextPosition):
         """
         TextPosition.__init__(self, line, column)
 
-        self._file = os.path.abspath(file)
+        self._file = abspath(file)
 
     @property
     def file(self):
         return self._file
+
+    def __json__(self, use_relpath=False):
+        _dict = get_public_members(self)
+        if use_relpath:
+            _dict['file'] = relpath(_dict['file'])
+        return _dict

--- a/coalib/results/SourceRange.py
+++ b/coalib/results/SourceRange.py
@@ -1,4 +1,6 @@
-from coalib.misc.Decorators import enforce_signature
+from os.path import relpath
+
+from coalib.misc.Decorators import enforce_signature, get_public_members
 from coalib.results.SourcePosition import SourcePosition
 from coalib.results.TextRange import TextRange
 
@@ -80,3 +82,9 @@ class SourceRange(TextRange):
                                        tr.start.column,
                                        tr.end.line,
                                        tr.end.column)
+
+    def __json__(self, use_relpath=False):
+        _dict = get_public_members(self)
+        if use_relpath:
+            _dict['file'] = relpath(_dict['file'])
+        return _dict

--- a/coalib/tests/output/JSONEncoderTest.py
+++ b/coalib/tests/output/JSONEncoderTest.py
@@ -2,7 +2,7 @@ import json
 import unittest
 from datetime import datetime
 
-from coalib.output.JSONEncoder import JSONEncoder
+from coalib.output.JSONEncoder import create_json_encoder
 
 
 class TestClass1(object):
@@ -51,6 +51,7 @@ class JSONAbleClass(object):
 
 
 class JSONEncoderTest(unittest.TestCase):
+    JSONEncoder = create_json_encoder(use_relpath=True)
     kw = {"cls": JSONEncoder, "sort_keys": True}
 
     def test_builtins(self):

--- a/coalib/tests/results/DiffTest.py
+++ b/coalib/tests/results/DiffTest.py
@@ -2,7 +2,7 @@ import json
 import unittest
 from unittest.case import SkipTest
 
-from coalib.output.JSONEncoder import JSONEncoder
+from coalib.output.JSONEncoder import create_json_encoder
 from coalib.results.Diff import ConflictError, Diff, SourceRange
 
 
@@ -167,6 +167,7 @@ class DiffTest(unittest.TestCase):
         self.assertNotEqual(diff_1, diff_2)
 
     def test_json_export(self):
+        JSONEncoder = create_json_encoder()
         a = ["first\n", "second\n", "third\n"]
         b = ["first\n", "third\n"]
         diff = Diff.from_string_arrays(a, b)

--- a/coalib/tests/results/SourcePositionTest.py
+++ b/coalib/tests/results/SourcePositionTest.py
@@ -1,6 +1,8 @@
 import unittest
+from os.path import relpath
 
 from coalib.results.SourcePosition import SourcePosition
+from coalib.misc.ContextManagers import prepare_file
 
 
 class SourcePositionTest(unittest.TestCase):
@@ -29,6 +31,12 @@ class SourcePositionTest(unittest.TestCase):
             repr(uut),
             "<SourcePosition object\\(file='.*None', line=None, column=None\\) "
                 "at 0x[0-9a-fA-F]+>")
+
+    def test_json(self):
+        with prepare_file([""], None) as (_, filename):
+            uut = SourcePosition(filename, 1)
+            self.assertEqual(uut.__json__(use_relpath=True)
+                             ['file'], relpath(filename))
 
     def assert_equal(self, first, second):
         self.assertGreaterEqual(first, second)

--- a/coalib/tests/results/SourceRangeTest.py
+++ b/coalib/tests/results/SourceRangeTest.py
@@ -65,6 +65,11 @@ class SourceRangeTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             SourceRange(self.result_fileB_noline, self.result_fileB_line2) < 1
 
+    def test_json(self):
+        uut = SourceRange.from_values("B", start_line=2,
+                                      end_line=4).__json__(use_relpath=True)
+        self.assertEqual(uut['start'], self.result_fileB_line2)
+
 
 class SourceRangeExpandTest(unittest.TestCase):
 

--- a/coalib/tests/settings/ConfigurationGatheringTest.py
+++ b/coalib/tests/settings/ConfigurationGatheringTest.py
@@ -47,8 +47,9 @@ class ConfigurationGatheringTest(unittest.TestCase):
                               "-s"]))
 
         self.assertEqual(str(sections["default"]),
-                         "Default {config : " + repr(temporary) + ", save : "
-                         "'True', test : '5'}")
+                         "Default {config : " +
+                         repr(temporary) + ", relpath : 'False'"
+                         ", save : 'True', test : '5'}")
 
         with make_temp() as temporary:
             sections, local_bears, global_bears, targets = (
@@ -186,8 +187,8 @@ class ConfigurationGatheringTest(unittest.TestCase):
 
         with open(filename, "r") as f:
             lines = f.readlines()
-        self.assertEqual(["[Default]\n", "config = some_bad_filename\n"],
-                         lines)
+        self.assertEqual(["[Default]\n", "config = some_bad_filename\n",
+                          "relpath = False\n"], lines)
 
         gather_configuration(
             lambda *args: True,
@@ -204,7 +205,7 @@ class ConfigurationGatheringTest(unittest.TestCase):
             filename = escape(filename, '\\')
         self.assertEqual(["[Default]\n",
                           "config = " + filename + "\n",
-                          "\n",
+                          "relpath = False\n", "\n",
                           "[test]\n",
                           "value = 5\n"], lines)
 


### PR DESCRIPTION
This commit changes the path for affected files from absolute
to relative path w.r.t current directory path. This change
is essential for coala-html to work

Fixes https://github.com/coala-analyzer/coala/issues/1593