### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,13 +20,11 @@ htmlcov
 *.sublime-project
 *.sublime-workspace
 .python-version
-coala.egg-info
+*.egg-info
 .coverage.*
-coala.1
 src
 site
 .zanata-cache
-org.coala_analyzer.v1.service
 *.exe
 .cache
 *.eggs


### PR DESCRIPTION
I have done this patch to remove the redundant things such as coala.1, org.coala_analyzer.v1.service, and to modify coala.egg_info to be, more generally, *.egg-info.