### PR TITLE
Self Correcting Bears doc: Fix typo

### DIFF
--- a/docs/Users/Tutorials/Self_Correcting_Bears.rst
+++ b/docs/Users/Tutorials/Self_Correcting_Bears.rst
@@ -67,7 +67,7 @@ is used to get the final output (which may be suggestions or
 auto-corrections).
 
 Let's try this bear out. Create a new file called ``sample.cpp``. Contents of
-``sameple.cpp`` are:
+``sample.cpp`` are:
 
 ::
 


### PR DESCRIPTION
Fixed a minor typo in `Self_Correcting_Bears.rst`