### PR TITLE
Constants.py: Added newlines to crash message

### DIFF
--- a/coalib/misc/Constants.py
+++ b/coalib/misc/Constants.py
@@ -4,12 +4,12 @@ import platform
 THIS_IS_A_BUG = ("This is a bug. We are sorry for the inconvenience. "
                  "Please contact the developers for assistance.")
 
-CRASH_MESSAGE = ("An unknown error occurred. This is a bug. We are "
-                 "sorry for the inconvenience. Please contact the "
-                 "developers for assistance. During execution of "
-                 "coala an exception was raised. This should never "
-                 "happen. When asked for, the following information "
-                 "may help investigating:")
+CRASH_MESSAGE = ("An unknown error occurred. This is a bug. We are \n"
+                 "sorry for the inconvenience. Please contact the \n"
+                 "developers for assistance. During execution of \n"
+                 "coala an exception was raised. This should never \n"
+                 "happen. When asked for, the following information \n"
+                 "may help investigating:\n")
 
 OBJ_NOT_ACCESSIBLE = "{} is not accessible and will be ignored!"
 


### PR DESCRIPTION
 Constants.py: Added newlines to crash message

As of now the crash message is just one single line without any newlines, this commit adds newlines to this message, the file can be found at coala/coalib/misc/Constants.py

Fixes https://github.com/coala-analyzer/coala/issues/1708