### PR TITLE
ConsoleInteraction: Refactor format_str

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -231,9 +231,9 @@ def print_results_formatted(log_printer,
                             *args):
     format_str = str(section.get(
         "format_str",
-        "id:{id}:origin:{origin}:file:{file}:from_line:{line}:from_column:"
-        "{column}:to_line:{end_line}:to_column:{end_column}:severity:"
-        "{severity}:severity_str:{severity_str}:msg:{message}"))
+        "id:{id}:origin:{origin}:file:{file}:line:{line}:column:"
+        "{column}:end_line:{end_line}:end_column:{end_column}:severity:"
+        "{severity}:severity_str:{severity_str}:message:{message}"))
     for result in result_list:
         severity_str = RESULT_SEVERITY.__str__(result.severity)
         try:

--- a/coalib/tests/coalaFormatTest.py
+++ b/coalib/tests/coalaFormatTest.py
@@ -23,7 +23,7 @@ class coalaFormatTest(unittest.TestCase):
                                            "-c", os.devnull,
                                            "-f", re.escape(filename),
                                            "-b", "LineCountTestBear")
-            self.assertRegex(output, r'msg:This file has [0-9]+ lines.',
+            self.assertRegex(output, r'message:This file has [0-9]+ lines.',
                              "coala-format output for line count should "
                              "not be empty")
             self.assertEqual(retval, 1,

--- a/coalib/tests/output/ConsoleInteractionTest.py
+++ b/coalib/tests/output/ConsoleInteractionTest.py
@@ -642,9 +642,9 @@ class PrintFormattedResultsTest(unittest.TestCase):
         self.section = Section("t")
 
     def test_default_format(self):
-        expected_string = ("id:-?[0-9]+:origin:1:file:None:from_line:None:"
-                           "from_column:None:to_line:None:to_column:None:"
-                           "severity:1:severity_str:NORMAL:msg:2\n")
+        expected_string = ("id:-?[0-9]+:origin:1:file:None:line:None:"
+                           "column:None:end_line:None:end_column:None:"
+                           "severity:1:severity_str:NORMAL:message:2\n")
         with retrieve_stdout() as stdout:
             print_results_formatted(self.logger,
                                     self.section,
@@ -655,12 +655,12 @@ class PrintFormattedResultsTest(unittest.TestCase):
 
     def test_multiple_ranges(self):
         expected_string = (
-            "id:-?[0-9]+:origin:1:.*file:.*another_file:from_line:5:"
-            "from_column:3:to_line:5:to_column:5:"
-            "severity:1:severity_str:NORMAL:msg:2\n"
-            "id:-?[0-9]+:origin:1:.*file:.*some_file:from_line:5:"
-            "from_column:None:to_line:7:to_column:None:"
-            "severity:1:severity_str:NORMAL:msg:2\n")
+            "id:-?[0-9]+:origin:1:.*file:.*another_file:line:5:"
+            "column:3:end_line:5:end_column:5:"
+            "severity:1:severity_str:NORMAL:message:2\n"
+            "id:-?[0-9]+:origin:1:.*file:.*some_file:line:5:"
+            "column:None:end_line:7:end_column:None:"
+            "severity:1:severity_str:NORMAL:message:2\n")
         affected_code = (SourceRange.from_values("some_file", 5, end_line=7),
                          SourceRange.from_values("another_file", 5, 3, 5, 5))
         with retrieve_stdout() as stdout:


### PR DESCRIPTION
ConsoleInteraction: Refactor format_str

In ConsoleInteraction.py, changed format_str in print_results_formatted
to match params. Also made changes to ConsoleInteractionTest.py
for consistency.

Fixes #1701 
