### PR TITLE
Install.rst: Fix typo in documentation

### DIFF
--- a/docs/Users/Install.rst
+++ b/docs/Users/Install.rst
@@ -91,7 +91,7 @@ the corresponding environment.
         $ venv\scripts\activate
 
 Finally, you install coala and supported bears inside the activated
-vertualenv with:
+virtualenv with:
 
 ::
 


### PR DESCRIPTION
Changed vertualenv to virtualenv in docs/Users/Install.rst

Fixes https://github.com/coala-analyzer/coala/issues/1691