### PR TITLE
Exceptions.py: catch ContextualVersionConflict

### DIFF
--- a/coalib/misc/Exceptions.py
+++ b/coalib/misc/Exceptions.py
@@ -2,6 +2,7 @@ from pyprint.NullPrinter import NullPrinter
 
 from coalib.misc import Constants
 from coalib.output.printers.LogPrinter import LogPrinter
+from pkg_resources import ContextualVersionConflict
 
 
 def get_exitcode(exception, log_printer=None):
@@ -15,6 +16,9 @@ def get_exitcode(exception, log_printer=None):
         exitcode = 0
     elif isinstance(exception, SystemExit):
         exitcode = exception.code
+    elif isinstance(exception, ContextualVersionConflict):
+        print("Version Conflict Error. Check 'pkg_resources'.")
+        exitcode = 777
     elif isinstance(exception, BaseException):
         log_printer.log_exception(Constants.CRASH_MESSAGE, exception)
         exitcode = 255

--- a/coalib/tests/misc/ExceptionsTest.py
+++ b/coalib/tests/misc/ExceptionsTest.py
@@ -1,6 +1,7 @@
 import unittest
 
 from coalib.misc.Exceptions import get_exitcode
+from pkg_resources import ContextualVersionConflict
 
 
 class ExceptionsTest(unittest.TestCase):
@@ -10,4 +11,5 @@ class ExceptionsTest(unittest.TestCase):
         self.assertEqual(get_exitcode(AssertionError()), 255)
         self.assertEqual(get_exitcode(SystemExit(999)), 999)
         self.assertEqual(get_exitcode(EOFError()), 0)
+        self.assertEqual(get_exitcode(ContextualVersionConflict()), 777)
         self.assertEqual(get_exitcode(None), 0)


### PR DESCRIPTION
This commit adds custom error handling for `pkg_resources` version
conflicts.

Fixes https://github.com/coala-analyzer/coala/issues/1748