### PR TITLE
coala_delete_orig: Remove redundant message

### DIFF
--- a/coalib/coala_delete_orig.py
+++ b/coalib/coala_delete_orig.py
@@ -13,7 +13,6 @@ def main(log_printer=None, section: Section=None):
     log_printer = log_printer or LogPrinter(ConsolePrinter())
 
     if start_path is None:
-        log_printer.err("Can only delete .orig files if .coafile is found")
         return 255
 
     orig_files = Globbing.glob(os.path.abspath(

--- a/coalib/tests/coalaDeleteOrigTest.py
+++ b/coalib/tests/coalaDeleteOrigTest.py
@@ -18,10 +18,8 @@ class coalaDeleteOrigTest(unittest.TestCase):
     def test_nonexistent_coafile(self):
         old_getcwd = os.getcwd
         os.getcwd = lambda *args: None
-        with retrieve_stdout() as stdout:
-            retval = coala_delete_orig.main()
-            self.assertIn("Can only delete .orig files if ", stdout.getvalue())
-            self.assertEqual(retval, 255)
+        retval = coala_delete_orig.main()
+        self.assertEqual(retval, 255)
         os.getcwd = old_getcwd
 
     def test_remove_exception(self):


### PR DESCRIPTION
When the user doesn't specify a `.coafile` there
is already an error message saying so, making this
line redundant.

Fixes https://github.com/coala-analyzer/coala/issues/1688