### PR TITLE
.travis.yml: Fix typo xontainer -> container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language:
   # The `objective-c` language by default uses a OSX build container. This
-  # is the currently supported method of using a OSX xontainer.
+  # is the currently supported method of using a OSX container.
   - objective-c
 
 env:


### PR DESCRIPTION
.travis.yml : Fix the typo xontainer -> container

The third commented line had a typo "xontainer", which got fixed in this commit to "container".

Fixes https://github.com/coala-analyzer/coala/issues/1755 