### PR TITLE
Decorators: Improves documentation

### DIFF
--- a/coalib/misc/Decorators.py
+++ b/coalib/misc/Decorators.py
@@ -92,11 +92,11 @@ def _construct_repr_string(obj, members):
 
 def get_public_members(obj):
     """
-    Retrieves a list of member-like objects (members or properties) that are
-    publically exposed.
+    Retrieves a dictionary of member-like objects (members or properties) that
+    are publicly exposed.
 
     :param obj: The object to probe.
-    :return:    A list of strings.
+    :return:    A dictionary with objects as keys and its attributes as values.
     """
     return {attr: getattr(obj, attr) for attr in dir(obj)
             if not attr.startswith("_")


### PR DESCRIPTION
Documentation of get_public_members(obj) incorrectly mentions that
the method returns a list, whereas actually a dictionary is returned.
The Documentation is corrected and the key-value pair is mentioned.

Fixes coala-analyzer#1739