### PR TITLE
gitignore: Add venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ node_modules
 .vendor
 Goopfile.lock
 docs/API/
+vnev


### PR DESCRIPTION
vnev added to gitignore.

Fixes #1761 