### PR TITLE
bear ignore: Add inline glob for bear ignore

### DIFF
--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -20,6 +20,7 @@ from coalib.results.result_actions.ShowPatchAction import ShowPatchAction
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 from coalib.results.SourceRange import SourceRange
 from coalib.settings.Setting import path_list
+from coalib.parsing.Globbing import fnmatch
 
 ACTIONS = [ApplyPatchAction,
            PrintDebugMessageAction,
@@ -168,11 +169,13 @@ def check_result_ignore(result, ignore_ranges):
                           cased affected bearnames and a SourceRange to
                           ignore. If any of the bearname lists is empty, it
                           is considered an ignore range for all bears.
+                          This may be a list of globbed bear wildcards.
     :return:              True if the result has to be ignored.
     """
     for bears, range in ignore_ranges:
-        if ((len(bears) == 0 or result.origin.lower() in bears) and
-                result.overlaps(range)):
+        orig = result.origin.lower()
+        if (result.overlaps(range) and
+                (len(bears) == 0 or orig in bears or fnmatch(orig, bears))):
             return True
 
     return False

--- a/coalib/tests/processes/ProcessingTest.py
+++ b/coalib/tests/processes/ProcessingTest.py
@@ -344,6 +344,40 @@ class ProcessingTest(unittest.TestCase):
                    SourceRange.from_values("e", 1, 1, 2, 2))]
         self.assertTrue(check_result_ignore(result, ranges))
 
+    def test_ignore_glob(self):
+        result = Result.from_values("LineLengthBear",
+                                    "message",
+                                    file="d",
+                                    line=1,
+                                    column=1,
+                                    end_line=2,
+                                    end_column=2)
+        ranges = [(["(line*|space*)", "py*"],
+                   SourceRange.from_values("d", 1, 1, 2, 2))]
+        self.assertTrue(check_result_ignore(result, ranges))
+
+        result = Result.from_values("SpaceConsistencyBear",
+                                    "message",
+                                    file="d",
+                                    line=1,
+                                    column=1,
+                                    end_line=2,
+                                    end_column=2)
+        ranges = [(["(line*|space*)", "py*"],
+                   SourceRange.from_values("d", 1, 1, 2, 2))]
+        self.assertTrue(check_result_ignore(result, ranges))
+
+        result = Result.from_values("XMLBear",
+                                    "message",
+                                    file="d",
+                                    line=1,
+                                    column=1,
+                                    end_line=2,
+                                    end_column=2)
+        ranges = [(["(line*|space*)", "py*"],
+                   SourceRange.from_values("d", 1, 1, 2, 2))]
+        self.assertFalse(check_result_ignore(result, ranges))
+
     def test_yield_ignore_ranges(self):
         test_file_dict_a = {'f':
                             ('# Ignore aBear\n',

--- a/docs/Users/Tutorials/Tutorial.rst
+++ b/docs/Users/Tutorials/Tutorial.rst
@@ -269,6 +269,21 @@ You can also conditionally combine ignore rules! Bear names will be
 split by comma and spaces, invalid bear names like ``and`` will be
 ignored.
 
+Also note that in the bear names delimited by commas and spaces, you may
+specify glob wildcards that match several bears:
+
+::
+
+    # Start ignoring Line*, Py*
+    unwrappable_string_2 = unwrappable_string + "yeah it goes even further..."
+    another_unwrappable_string = unwrappable_string + unwrappable_string_2
+    # Stop ignoring
+
+In the above example all bears matching the glob `Line*` and `Py*` will
+be ignored. You may also specify more complex globs here such as
+`# Start ignoring (Line*|P[yx]*)` which will ignore all bears start with
+`Line`, `Py`, and `Px`.
+
 ::
 
     # Ignore LineLengthBear and SpaceConsistencyBear


### PR DESCRIPTION
Previously a comment with `ignore` followed by
bear names in it will result in the following line
not being impacted by the bears. This commit
introduces globs for the same so that multiple matching
bears can be ignored easily.

Fixes https://github.com/coala-analyzer/coala/issues/1781