### PR TITLE
coalib/results/Diff.py: Fix typo in from_clang_fixit class

### DIFF
--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -69,7 +69,7 @@ class Diff:
         """
         Creates a Diff object from a given clang fixit and the file contents.
 
-        :param fixit: A cindex.Fixit obejct.
+        :param fixit: A cindex.Fixit object.
         :param file:  A list of lines in the file to apply the fixit to.
         :return:      The corresponding Diff object.
         """


### PR DESCRIPTION
Fixes https://github.com/coala-analyzer/coala/issues/1765