### PR TITLE
Lint: Refactor prerequisite checking

### DIFF
--- a/tests/bearlib/abstractions/LintTest.py
+++ b/tests/bearlib/abstractions/LintTest.py
@@ -107,7 +107,7 @@ class LintTest(unittest.TestCase):
         out = tuple(self.uut.process_output(["a", "b"], "filename", ["a"]))
         self.assertEqual(len(out), 1)
 
-    def test_missing_binary(self):
+    def test_missing_executable(self):
         old_binary = Lint.executable
         invalid_binary = "invalid_binary_which_doesnt_exist"
         Lint.executable = invalid_binary
@@ -119,10 +119,19 @@ class LintTest(unittest.TestCase):
         Lint.executable = "echo"
         self.assertTrue(Lint.check_prerequisites())
 
-        del Lint.executable
+        Lint.executable = old_binary
+
+        old_command = Lint.prerequisite_command
+        invalid_command = ["cat", "SOPA"]
+        Lint.prerequisite_command = invalid_command
+
+        self.assertEqual(Lint.check_prerequisites(), Lint.prerequisite_fail_msg)
+
+        Lint.prerequisite_command = ["cat", "requirements.txt"]
+
         self.assertTrue(Lint.check_prerequisites())
 
-        Lint.executable = old_binary
+        Lint.prerequisite_command = old_command
 
     def test_config_file_generator(self):
         self.uut.executable = "echo"

--- a/tests/bearlib/abstractions/LintTest.py
+++ b/tests/bearlib/abstractions/LintTest.py
@@ -141,7 +141,7 @@ class LintTest(unittest.TestCase):
             self.uut._create_command(config_file="configfile").strip(),
             "echo -c " + escape_path_argument("configfile"))
 
-    def test_config_file_generator(self):
+    def test_generate_config_file_generator(self):
         self.uut.executable = "echo"
         self.uut.config_file = lambda: ["config line1"]
         config_filename = self.uut.generate_config_file()


### PR DESCRIPTION
Sometimes, linter bears need to check for a command as a
prerequisite. This commit introduces two new variables:

* prerequisite_command: the command to run as a list
* prerequisite_fail_msg: the message to display if the command
fails.

Two function now check for prerequisites:

* _check_executable() -> checks if the executable presents
* _check_command() -> check if the command prerequisite_command
returns an exitcode 0, else return prerequisite_fail_msg

Fixes coala-analyzer#1803