### PR TITLE
coalang: Change multiword keys to be underscored

### DIFF
--- a/coalib/bearlib/languages/definitions/__init__.py
+++ b/coalib/bearlib/languages/definitions/__init__.py
@@ -8,8 +8,8 @@ Currently defined keys are:
 
   names
   extensions
-  comment delimiter
-  multiline comment delimiters
-  string delimiters
-  multiline string delimiters
+  comment_delimiter
+  multiline_comment_delimiters
+  string_delimiters
+  multiline_string_delimiters
 """

--- a/coalib/bearlib/languages/definitions/c.coalang
+++ b/coalib/bearlib/languages/definitions/c.coalang
@@ -1,13 +1,13 @@
 [DEFAULT]
-comment\ delimiter = //
-multiline\ comment\ delimiters = /*: */
-string\ delimiters = ": "
-indent\ types = { : }
+comment_delimiter = //
+multiline_comment_delimiters = /*: */
+string_delimiters = ": "
+indent_types = { : }
 
 [C]
 extensions = .c, .h
-multiline\ string\ delimiters =
+multiline_string_delimiters =
 
 [CPP]
 extensions = .c, .cpp, .h, .hpp
-multiline\ string\ delimiters = R(": )"
+multiline_string_delimiters = R(": )"

--- a/coalib/bearlib/languages/definitions/python3.coalang
+++ b/coalib/bearlib/languages/definitions/python3.coalang
@@ -1,11 +1,11 @@
 [DEFAULT]
 extensions = .py
 
-comment\ delimiter = #
-multiline\ comment\ delimiters =
-string\ delimiters = ": ", ': '
-multiline\ string\ delimiters = """: """, ''': '''
-indent\ types = \:
+comment_delimiter = #
+multiline_comment_delimiters =
+string_delimiters = ": ", ': '
+multiline_string_delimiters = """: """, ''': '''
+indent_types = \:
 
 [PYTHON3]
 


### PR DESCRIPTION
Currently .coalang files use escaped spaces for
multiword keys (example: `comment\ delimiter`). This
reduces readability a lot. Using underscores instead
will make this much easier and also future proof this.