### PR TITLE
coalang: Add keywords and special characters

### DIFF
--- a/coalib/bearlib/languages/LanguageDefinition.py
+++ b/coalib/bearlib/languages/LanguageDefinition.py
@@ -32,3 +32,6 @@ class LanguageDefinition(SectionCreatable):
 
     def __getitem__(self, item):
         return self.lang_dict[item]
+
+    def __contains__(self, item):
+        return item in self.lang_dict

--- a/coalib/bearlib/languages/definitions/__init__.py
+++ b/coalib/bearlib/languages/definitions/__init__.py
@@ -12,4 +12,6 @@ Currently defined keys are:
   multiline_comment_delimiters
   string_delimiters
   multiline_string_delimiters
+  keywords
+  special_chars
 """

--- a/coalib/bearlib/languages/definitions/c.coalang
+++ b/coalib/bearlib/languages/definitions/c.coalang
@@ -7,7 +7,26 @@ indent_types = { : }
 [C]
 extensions = .c, .h
 multiline_string_delimiters =
+keywords = auto, break, case, char, const, continue, default, do, double,
+else, enum, extern, float, for, goto, if, int, long, register, return, short,
+signed, sizeof, static, struct, switch, typedef, union, unsigned, void,
+volatile, while, \#include, \#define, \#undef, \#ifdef, \#ifndef,
+\#if, \#endif, \#else, \#elif, \#line, \#pragma
+special_chars = +-*\/.;\\,()[]{}\=<>|&^~?%!
 
 [CPP]
 extensions = .c, .cpp, .h, .hpp
 multiline_string_delimiters = R(": )"
+keywords = alignas, alignof, and, and_eq, asm, auto, bitand, bitor, bool,
+break, case, catch, char, char16_t, char32_t, class, compl, concept,
+const, constexpr, const_cast, continue, decltype, default, delete, do,
+double, dynamic_cast, else, enum, explicit, export, extern, false, float,
+for, friend, goto, if, inline, int, long, mutable, namespace, new, noexcept,
+not, not_eq, nullptr, operator, or, or_eq, private, protected, public,
+register, reinterpret_cast, requires, return, short, signed, sizeof,
+static, static_assert, static_cast, struct, switch, template, this,
+thread_local, throw, true, try, typedef, typeid, typename, union,
+unsigned, using, virtual, void, volatile, wchar_t, while, xor, xor_eq,
+\#include, \#define, \#undef, \#ifdef, \#ifndef, \#if, \#endif, \#else,
+\#elif, \#line, \#pragma
+special_chars = +-*\/.;\\,()[]{}\=<>|&^~?%!

--- a/tests/bearlib/languages/LanguageDefinitionTest.py
+++ b/tests/bearlib/languages/LanguageDefinitionTest.py
@@ -25,3 +25,8 @@ class LanguageDefinitionTest(unittest.TestCase):
     def test_loading(self):
         uut = LanguageDefinition.from_section(self.section)
         self.assertEqual(list(uut["extensions"]), [".c", ".cpp", ".h", ".hpp"])
+
+    def test_key_contains(self):
+        uut = LanguageDefinition.from_section(self.section)
+        self.assertIn("extensions", uut)
+        self.assertNotIn("randomstuff", uut)


### PR DESCRIPTION
Add keywords and special characters for C and C++
Also added two new routines in coalang LanguageDefinition
that are useful.