### PR TITLE
.coafile: Add disabled section for docs

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -86,6 +86,12 @@ enabled = False
 
 bears = LineCountBear
 
+[invalidlinks]
+enabled = False
+files = docs/**/*.rst
+ignore = docs/API
+bears = InvalidLinkBear
+
 [TODOS]
 enabled = False
 


### PR DESCRIPTION
This section currently checks for broken or invalid
links into our docs, but is currently disabled so it
passes CI tests. It can be simply be enabled and ran
for a newcomer to replace or remove the links :)

Fixes https://github.com/coala-analyzer/coala/issues/1812