### PR TITLE
ConsoleInteraction: Catch bullet unicode error

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -128,7 +128,10 @@ def print_spaces_tabs_in_unicode(console_printer, line, tab_dict,
     """
     for char in line:
         if char == " ":
-            console_printer.print("•", color='cyan', end='')
+            try:
+                console_printer.print("•", color='cyan', end='')
+            except UnicodeEncodeError:
+                console_printer.print(".", color='cyan', end='')
         elif char == '\t' and tab_dict:
             tab_count = tab_dict[index]
             console_printer.print(

--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -116,15 +116,16 @@ def acquire_actions_and_apply(console_printer,
 def print_spaces_tabs_in_unicode(console_printer, line, tab_dict,
                                  tab_width, color, index=0):
     """
-    Prints the lines with tabs and spaces replaced by unicode
-    symbols.
+    Prints the lines with tabs and spaces replaced by unicode symbols.
 
-    :param console_printer: Object to print messages on the console.
-    :param line:            The line to print to the console.
-    :param tab_dict:        A dictionary containing the tab index and length.
-    :param tab_width:       The default tab width of the system.
-    :color:                 The color to print the lines with.
-    :index:                 The index from where to start the printing.
+    :param console_printer: The ``Printer`` object to print to.
+    :param line:            The line-text to print to ``console_printer``.
+    :param tab_dict:        A dictionary containing the indices of tabs inside
+                            ``line`` as keys and the tab-length as values.
+    :param tab_width:       The width of tabs.
+    :param color:           The color to print the line with (except for spaces
+                            and tabs.
+    :param index:           The index from where to start the printing.
     """
     for char in line:
         if char == " ":

--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -6,6 +6,7 @@ from os.path import abspath, relpath
 from pyprint.ConsolePrinter import ConsolePrinter
 from pyprint.NullPrinter import NullPrinter
 
+from coalib.bearlib.spacing.SpacingHelper import SpacingHelper
 from coalib.bears.Bear import Bear
 from coalib.misc.ContextManagers import (
     make_temp, retrieve_stdout, simulate_console_inputs)
@@ -13,7 +14,7 @@ from coalib.output.ConsoleInteraction import (
     acquire_actions_and_apply, acquire_settings, get_action_info, nothing_done,
     print_affected_files, print_bears, print_result, print_results,
     print_results_formatted, print_results_no_input, print_section_beginning,
-    show_bears)
+    print_spaces_tabs_in_unicode, show_bears)
 from coalib.output.printers.LogPrinter import LogPrinter
 from coalib.output.printers.StringPrinter import StringPrinter
 from coalib.results.Diff import Diff
@@ -120,6 +121,39 @@ class ConsoleInteractionTest(unittest.TestCase):
     def tearDown(self):
         OpenEditorAction.is_applicable = self.old_open_editor_applicable
         ApplyPatchAction.is_applicable = self.old_apply_patch_applicable
+
+    def test_print_spaces_tabs_in_unicode(self):
+        printer = StringPrinter()
+
+        sh = SpacingHelper(4)
+
+        test_string = "\the\tllo world   "
+        print_spaces_tabs_in_unicode(
+            printer,
+            test_string,
+            dict(sh.yield_tab_lengths(test_string)),
+            4,
+            "red")
+        self.assertEqual(printer.string, "--->he->llo•world•••")
+
+        # Test the case when the bullet can't be printed because of encoding
+        # problems.
+        def hijack_print(text, *args, **kwargs):
+            if "•" in text:
+                raise UnicodeEncodeError("test-codec", "", 0, 1, "")
+            else:
+                return StringPrinter.print(printer, text, *args, **kwargs)
+
+        printer.print = hijack_print
+
+        printer.clear()
+        test_string = " he\tllo  world "
+        print_spaces_tabs_in_unicode(printer,
+                                     test_string,
+                                     dict(sh.yield_tab_lengths(test_string)),
+                                     4,
+                                     "red")
+        self.assertEqual(printer.string, ".he>llo..world.")
 
     def test_require_settings(self):
         self.assertRaises(TypeError, acquire_settings, self.log_printer, 0)


### PR DESCRIPTION
When printing the bullet-character that represents a whitespace, a
`UnicodeEncodeError` can be thrown and is thrown on Windows systems
since Windows uses by default cp1252 or a similar codec that can't
handle this character.