### PR TITLE
coala_html.py: Add coala-html binary

### DIFF
--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import sys
 
 from coalib.misc import Constants
@@ -15,7 +16,7 @@ def default_arg_parser(formatter_class=None):
 
     entry_point = sys.argv[0]
     for entry in ['coala-ci', 'coala-dbus', 'coala-format', 'coala-json',
-                  'coala-delete-orig']:
+                  'coala-html', 'coala-delete-orig']:
         if entry_point.endswith(entry):
             parser_type = entry
             break
@@ -119,6 +120,26 @@ def default_arg_parser(formatter_class=None):
                                 metavar='BOOL',
                                 help='Write the logs as json to a file '
                                 'where filename is specified as argument.')
+    if parser_type == 'coala-html':
+        arg_parser.add_argument('-N',
+                                '--noupdate',
+                                nargs='?',
+                                const=True,
+                                metavar='BOOL',
+                                default=False,
+                                help='Launch webpage from existing results.')
+        arg_parser.add_argument('--dir',
+                                nargs='?',
+                                metavar='FILE',
+                                default=os.path.expanduser('~/_coalahtml'),
+                                help='Absolute path for storing webpages in '
+                                'directory.')
+        arg_parser.add_argument('--nolaunch',
+                                nargs='?',
+                                const=True,
+                                metavar='BOOL',
+                                default=False,
+                                help='Launch webpage')
     if parser_type == 'coala':
         SHOW_BEARS_HELP = ("Display bears and its metadata with the sections "
                            "that they belong to")


### PR DESCRIPTION
~~Install coala-html angular app via bower. Also install the bower dependencies.~~

- [x]  run coala and dump the results in json format to a particular file if it doesn't exists else update it. This file shall be used by Angular app.

- [ ] create `file.json` if it doesn't exists else update it.

- [x] Finally, create a server and open the file. This can have some flexibility. User can decide whether to launch the webpage immediately after running coala-html or maybe just update/create the files.

Fixes https://github.com/coala-analyzer/coala-html/issues/31