### PR TITLE
coafile: Add option to ignore coafile

### DIFF
--- a/coalib/parsing/CliParsing.py
+++ b/coalib/parsing/CliParsing.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from argparse import ArgumentParser
 from collections import OrderedDict
 
 from coalib.parsing.DefaultArgParser import default_arg_parser
@@ -87,3 +88,25 @@ def parse_custom_settings(sections,
                                origin=origin,
                                section_name=key_touple[0],
                                from_cli=True)
+
+
+def check_conflicts(sections):
+    '''
+    Checks if there are any conflicting aruments passed
+
+    :return:            True if no conflicts
+    :raises SystemExit: If there are conflicting arguments (exit code: 2)
+    '''
+    conflicts = {'no_config': {'save', 'find_config'}}
+    conflicting_keys = conflicts.keys()
+
+    for section in sections:
+        keys = set(sections[section])
+        possible_conflicts = keys & conflicting_keys
+        for key in possible_conflicts:
+            intersection = keys & conflicts[key]
+            if len(intersection) > 0:
+                ArgumentParser().exit(2,
+                                      key + " cannot be given at the same "
+                                      "time with " + (', '.join(intersection)))
+    return True

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -50,6 +50,12 @@ def default_arg_parser(formatter_class=None):
                             const=True,
                             metavar='BOOL',
                             help=FIND_CONFIG_HELP)
+    arg_parser.add_argument('-I',
+                            '--no-config',
+                            nargs='?',
+                            const=True,
+                            metavar='BOOL',
+                            help="Run without using any config file")
     arg_parser.add_argument('-f',
                             '--files',
                             nargs='+',

--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -5,7 +5,7 @@ import sys
 from coalib.misc import Constants
 from coalib.output.ConfWriter import ConfWriter
 from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
-from coalib.parsing.CliParsing import parse_cli
+from coalib.parsing.CliParsing import parse_cli, check_conflicts
 from coalib.parsing.ConfParser import ConfParser
 from coalib.settings.Section import Section
 from coalib.settings.SectionFilling import fill_settings
@@ -114,6 +114,7 @@ def load_configuration(arg_list, log_printer):
                         indicated after colon.)
     """
     cli_sections = parse_cli(arg_list=arg_list)
+    check_conflicts(cli_sections)
 
     if (
             bool(cli_sections["default"].get("find_config", "False")) and
@@ -126,33 +127,37 @@ def load_configuration(arg_list, log_printer):
     for item in list(cli_sections["default"].contents.pop("targets", "")):
         targets.append(item.lower())
 
-    default_sections = load_config_file(Constants.system_coafile,
-                                        log_printer)
+    if bool(cli_sections["default"].get("no_config", "False")):
+        sections = cli_sections
+    else:
+        default_sections = load_config_file(Constants.system_coafile,
+                                            log_printer)
+        user_sections = load_config_file(
+            Constants.user_coafile,
+            log_printer,
+            silent=True)
 
-    user_sections = load_config_file(
-        Constants.user_coafile,
-        log_printer,
-        silent=True)
+        default_config = str(
+            default_sections["default"].get("config", ".coafile"))
+        user_config = str(user_sections["default"].get(
+            "config", default_config))
+        config = os.path.abspath(
+            str(cli_sections["default"].get("config", user_config)))
 
-    default_config = str(default_sections["default"].get("config", ".coafile"))
-    user_config = str(user_sections["default"].get("config", default_config))
-    config = os.path.abspath(
-        str(cli_sections["default"].get("config", user_config)))
+        try:
+            save = bool(cli_sections["default"].get("save", "False"))
+        except ValueError:
+            # A file is deposited for the save parameter, means we want to save
+            # but to a specific file.
+            save = True
 
-    try:
-        save = bool(cli_sections["default"].get("save", "False"))
-    except ValueError:
-        # A file is deposited for the save parameter, means we want to save but
-        # to a specific file.
-        save = True
+        coafile_sections = load_config_file(config, log_printer, silent=save)
 
-    coafile_sections = load_config_file(config, log_printer, silent=save)
+        sections = merge_section_dicts(default_sections, user_sections)
 
-    sections = merge_section_dicts(default_sections, user_sections)
+        sections = merge_section_dicts(sections, coafile_sections)
 
-    sections = merge_section_dicts(sections, coafile_sections)
-
-    sections = merge_section_dicts(sections, cli_sections)
+        sections = merge_section_dicts(sections, cli_sections)
 
     for section in sections:
         if section != "default":

--- a/tests/parsing/CliParsingTest.py
+++ b/tests/parsing/CliParsingTest.py
@@ -1,7 +1,7 @@
 import argparse
 import unittest
 
-from coalib.parsing.CliParsing import parse_cli
+from coalib.parsing.CliParsing import parse_cli, check_conflicts
 
 
 class CliParserTest(unittest.TestCase):
@@ -52,3 +52,12 @@ class CliParserTest(unittest.TestCase):
         self.assertEqual(parsed_sections["default"].name, "Default")
         self.assertEqual(self.dict_from_sections(parsed_sections),
                          expected_dict)
+
+    def test_check_conflicts(self):
+        sections = parse_cli(arg_list=["--save", "--no-config"])
+        with self.assertRaises(SystemExit) as cm:
+            check_conflicts(sections)
+            self.assertEqual(cm.exception.code, 2)
+
+        sections = parse_cli(arg_list=["--no-config", "-S", "val=42"])
+        self.assertTrue(check_conflicts(sections))


### PR DESCRIPTION
When the user adds the flag `--no-config` to his coala command
the program will now default to the most basic coafile while
ignoring the coafile that may be present in the user diretory.

Fixes https://github.com/coala-analyzer/coala/issues/1838