### PR TITLE
docs: Fix typo in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -145,7 +145,7 @@ Status and Stability of the Project
 We are currently working hard to make this project reality. coala is currently
 usable, in beta stage and already provides more features than most
 language dependent alternatives. Every single commit is fully reviewed and
-checked with various automated methode including our testsuite covering all
+checked with various automated methods including our testsuite covering all
 braches. Our master branch is continuously prereleased to our users so you can
 rely on the upcoming release being rock stable.
 


### PR DESCRIPTION
Line 142 had a spelling mistake : 'methode' instead
of 'methods'.

Fixes https://github.com/coala-analyzer/coala/issues/1872