### PR TITLE
Change invalid links in documentation

### DIFF
--- a/docs/General_Dev_Info/git_tutorial_1.rst
+++ b/docs/General_Dev_Info/git_tutorial_1.rst
@@ -374,7 +374,7 @@ So, let's look in our repository!
 Now let's look into it further to get to know what it is a bit more. I
 will try to cover only important parts here, if you're interested even
 deeper, you can try DuckDuckGo or take a look at this:
-http://git-scm.com/docs/gitrepository-layout
+https://git-scm.com/docs/gitrepository-layout
 
 The config file
 ---------------
@@ -390,7 +390,7 @@ The objects directory is an important one: It contains our commits.
 
 One could do a full tutorial on those things but that's not covered
 here. If you want that, check out:
-http://git-scm.com/book/en/v2/Git-Internals-Git-Objects
+https://git-scm.com/book/en/v2/Git-Internals-Git-Objects
 
 We just saw the **ID** of the commit we made:
 ``ec6c903a0a18960cd73df18897e56738c4c6bb51``
@@ -549,7 +549,7 @@ In order to generally **ignore certain patterns** of files (e.g. it's
     README~  # Ignore gedit temporary files
     *.o  # Ignore compiled object files
 
-The **exact pattern** is defined here: http://git-scm.com/docs/gitignore
+The **exact pattern** is defined here: https://git-scm.com/docs/gitignore
 
 Files matching this pattern will:
 

--- a/docs/Getting_Involved/Newcomers.rst
+++ b/docs/Getting_Involved/Newcomers.rst
@@ -38,8 +38,12 @@ to contact us on gitter, and we will help you!
 Start working
 -------------
 
+.. Start ignoring InvalidLinkBear
+
 Now is the time to pick an issue.
 Here is the link that will lead you to `Newcomers issues <https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Acoala-analyzer+label%3Adifficulty%2Fnewcomer>`_.
+
+.. Stop ignoring InvalidLinkBear
 
 .. seealso::
 

--- a/docs/Getting_Involved/Writing_Documentation.rst
+++ b/docs/Getting_Involved/Writing_Documentation.rst
@@ -6,7 +6,7 @@ for the coala project.
 
 Documentation is written in reStructuredText and rendered by readthedocs.org to
 our lovely users. You can view the current documentation on
-http://coala.rtfd.org.
+http://coala.readthedocs.org/en/latest/.
 
 After getting the coala source code (see :doc:`Installation
 Instructions <../Users/Install>`), you can start hacking on

--- a/docs/Users/Install.rst
+++ b/docs/Users/Install.rst
@@ -6,11 +6,11 @@ platforms are Linux and Windows. coala is known to work on OS X as well.
 coala is tested against CPython 3.3, 3.4 and 3.5.
 
 In order to run coala you need to install Python. It is recommended,
-that you install Python3 >= 3.3 from http://www.python.org.
+that you install Python3 >= 3.3 from https://www.python.org/.
 
 The easiest way to install coala is using pip (Pip Installs Packages).
 If you don't already have pip, you can install it like described on
-https://pip.pypa.io/en/stable/installing.html. Note that pip is shipped
+https://pip.pypa.io/en/stable/installing/. Note that pip is shipped
 with recent python versions by default.
 
 System wide installation
@@ -58,7 +58,7 @@ Installing inside a virtualenv
 
 Virtualenv is probably what you want to use during development,
 you’ll probably want to use it there, too. You can read more about
-it at their documentation - http://virtualenv.readthedocs.org
+it at their documentation - http://virtualenv.readthedocs.org/en/latest/
 
 First, we need to install virtualenv to the system. This can be done
 with ``pip3`` easily:
@@ -101,7 +101,7 @@ Installing coala from source
 ----------------------------
 
 In order to install coala from source, it is recommended to install git.
-See http://git-scm.com/ for further information and a downloadable
+See https://git-scm.com/ for further information and a downloadable
 installer or use your package manager on linux to get it.
 
 .. note::
@@ -179,7 +179,7 @@ JS Dependencies
 
 coala features a lot of bears that use linters written in JavaScript. In
 order for them to be usable, you need to install them via ``npm``
-(http://nodejs.org/):
+(https://nodejs.org/en/):
 
 ::
 

--- a/docs/Users/Tutorials/Tutorial.rst
+++ b/docs/Users/Tutorials/Tutorial.rst
@@ -18,10 +18,12 @@ In order to perform a static code analysis on your code you will need
 some code to check. If you do not have own code you want to check, you
 can retrieve our tutorial samples:
 
+.. Start ignoring InvalidLinkBear
 ::
 
     git clone https://github.com/coala-analyzer/coala-tutorial.git
 
+.. Stop ignoring InvalidLinkBear
 Please note that the commands given in this tutorial are intended for
 use with this sample code and may need minor adjustments.
 
@@ -345,6 +347,7 @@ developers even to install coala using git submodules. This also has the
 advantage that all your developers are using exactly the same version of
 coala. You can try it out in the coala-tutorial repository:
 
+.. Start ignoring InvalidLinkBear
 ::
 
     git submodule add https://github.com/coala-analyzer/coala.git
@@ -352,6 +355,7 @@ coala. You can try it out in the coala-tutorial repository:
     git add .coafile
     git commit -m 'Add .coafile'
 
+.. Stop ignoring InvalidLinkBear
 You can now use ``coala/coala`` as if it were the installed binary.
 Here's the instructions for your developers:
 

--- a/docs/Users/Tutorials/Writing_Bears.rst
+++ b/docs/Users/Tutorials/Writing_Bears.rst
@@ -8,10 +8,11 @@ tutorial!
 The sample sources for this tutorial lie at our coala-tutorial
 repository, go clone it with:
 
+.. Start ignoring InvalidLinkBear
 ::
 
     git clone https://github.com/coala-analyzer/coala-tutorial.git
-
+.. Stop ignoring InvalidLinkBear
 All paths and commands given here are meant to be executed from the root
 directory of the coala-tutorial repository.
 


### PR DESCRIPTION
Broken links and repository links (.git links) fix.

Fixes https://github.com/coala-analyzer/coala/issues/1860