### PR TITLE
python3.coalang: Escape #

### DIFF
--- a/coalib/bearlib/languages/definitions/python3.coalang
+++ b/coalib/bearlib/languages/definitions/python3.coalang
@@ -1,7 +1,7 @@
 [DEFAULT]
 extensions = .py
 
-comment_delimiter = #
+comment_delimiter = \#
 multiline_comment_delimiters =
 string_delimiters = ": ", ': '
 multiline_string_delimiters = """: """, ''': '''


### PR DESCRIPTION
python3.coalang had an unescaped # which caused it to be
unrecognisable by the parser. This PR escapes that