### PR TITLE
Exceptions: Handle package version conflicts

### DIFF
--- a/coalib/misc/Constants.py
+++ b/coalib/misc/Constants.py
@@ -13,6 +13,15 @@ CRASH_MESSAGE = ("An unknown error occurred. This is a bug. We are "
                  "happen. When asked for, the following information "
                  "may help investigating:")
 
+VERSION_CONFLICT_MESSAGE = ("There is a conflict in the version of a "
+                            "dependency you have installed and the "
+                            "requirements of coala. This may be resolved by "
+                            "creating a separate virtual environment for "
+                            "coala or running `pip install %s`. Be aware "
+                            "that the latter solution might break other "
+                            "python packages that depend on the currently "
+                            "installed version.")
+
 OBJ_NOT_ACCESSIBLE = "{} is not accessible and will be ignored!"
 
 TRUE_STRINGS = ['1',

--- a/coalib/misc/Exceptions.py
+++ b/coalib/misc/Exceptions.py
@@ -3,6 +3,8 @@ from pyprint.NullPrinter import NullPrinter
 from coalib.misc import Constants
 from coalib.output.printers.LogPrinter import LogPrinter
 
+from pkg_resources import VersionConflict
+
 
 def get_exitcode(exception, log_printer=None):
     log_printer = log_printer or LogPrinter(NullPrinter())
@@ -15,6 +17,10 @@ def get_exitcode(exception, log_printer=None):
         exitcode = 0
     elif isinstance(exception, SystemExit):
         exitcode = exception.code
+    elif isinstance(exception, VersionConflict):
+        log_message = Constants.VERSION_CONFLICT_MESSAGE % str(exception.req)
+        log_printer.log_exception(log_message, exception)
+        exitcode = 13
     elif isinstance(exception, BaseException):
         log_printer.log_exception(Constants.CRASH_MESSAGE, exception)
         exitcode = 255

--- a/docs/Users/Exit_Codes.rst
+++ b/docs/Users/Exit_Codes.rst
@@ -11,6 +11,8 @@ The following is a list of coalas exit codes and their meanings:
 -  ``4`` - coala was executed with an unsupported version of python
 -  ``5`` - coala executed successfully. Results were found but patches
    to the results were applied successfully
+-  ``13`` - There is a conflict in the version of a dependency you have
+   installed and the requirements of coala.
 -  ``130`` - A KeyboardInterrupt (Ctrl+C) was pressed during the
    execution of coala.
 -  ``255`` - Any other general errors.

--- a/tests/misc/ExceptionsTest.py
+++ b/tests/misc/ExceptionsTest.py
@@ -1,6 +1,7 @@
 import unittest
 
 from coalib.misc.Exceptions import get_exitcode
+from pkg_resources import VersionConflict
 
 
 class ExceptionsTest(unittest.TestCase):
@@ -9,5 +10,7 @@ class ExceptionsTest(unittest.TestCase):
         self.assertEqual(get_exitcode(KeyboardInterrupt()), 130)
         self.assertEqual(get_exitcode(AssertionError()), 255)
         self.assertEqual(get_exitcode(SystemExit(999)), 999)
+        self.assertEqual(get_exitcode(VersionConflict(
+            "libclang-py3 0.3", "libclang-py3==0.2")), 13)
         self.assertEqual(get_exitcode(EOFError()), 0)
         self.assertEqual(get_exitcode(None), 0)


### PR DESCRIPTION
Currently, when a requirement for coala is not met, the
default crash message is printed and exited. This commits handles
this exception by displaying why coala crashed along with
information about which package is at fault.

Fixes https://github.com/coala-analyzer/coala/issues/1748