### PR TITLE
requirements: Use latest PyPrint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyPrint~=0.2.3
-setuptools~=19.2
+setuptools>=19.2
 # Do *not* use 0.3 which is not backwards compatible to common clang versions
 libclang-py3==0.2
 validators~=0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyPrint~=0.2.0
+PyPrint~=0.2.3
 setuptools~=19.2
 # Do *not* use 0.3 which is not backwards compatible to common clang versions
 libclang-py3==0.2


### PR DESCRIPTION
This one uses ~= and this we should escape dependency problems a bit.