### PR TITLE
Tutorial: Remove integrating section

### DIFF
--- a/docs/Users/Tutorials/Tutorial.rst
+++ b/docs/Users/Tutorials/Tutorial.rst
@@ -337,30 +337,6 @@ shows:
 -  The sections which uses it
 -  The settings it uses (optional and required)
 
-Integrating coala into Your Project
------------------------------------
-
-It's easy to add coala to your project in a way that does not force your
-developers even to install coala using git submodules. This also has the
-advantage that all your developers are using exactly the same version of
-coala. You can try it out in the coala-tutorial repository:
-
-::
-
-    git submodule add https://github.com/coala-analyzer/coala.git
-    git commit -m 'Add coala submodule'
-    git add .coafile
-    git commit -m 'Add .coafile'
-
-You can now use ``coala/coala`` as if it were the installed binary.
-Here's the instructions for your developers:
-
-::
-
-    git submodule init
-    git submodule update
-    coala/coala
-
 Continuing the Journey
 ----------------------
 


### PR DESCRIPTION
- Not a lot of users will want to use the latest unstable version of
  coala for their projects.
- coala without coala-bears is of not much use. And almost always there
  will be a need to install some dependencies for coala-bears.

Fixes https://github.com/coala-analyzer/coala/issues/1919