### PR TITLE
Bear: Add helper function name()

### DIFF
--- a/coalib/bearlib/abstractions/Lint.py
+++ b/coalib/bearlib/abstractions/Lint.py
@@ -227,7 +227,7 @@ class Lint(Bear):
                 groups[variable] = int(groups[variable])
 
         if "origin" in groups:
-            groups['origin'] = "{} ({})".format(str(self.__class__.__name__),
+            groups['origin'] = "{} ({})".format(str(self.name),
                                                 str(groups["origin"]))
 
         return Result.from_values(

--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -2,7 +2,7 @@ import traceback
 
 from pyprint.Printer import Printer
 
-from coalib.misc.Decorators import enforce_signature
+from coalib.misc.Decorators import enforce_signature, classproperty
 from coalib.output.printers.LogPrinter import LogPrinter
 from coalib.settings.FunctionMetadata import FunctionMetadata
 from coalib.settings.Section import Section
@@ -31,6 +31,13 @@ class Bear(Printer, LogPrinter):
 
     Settings are available at all times through self.section.
     """
+
+    @classproperty
+    def name(cls):
+        """
+        :return: The name of the bear
+        """
+        return cls.__name__
 
     @enforce_signature
     def __init__(self,

--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -67,7 +67,7 @@ class Bear(Printer, LogPrinter):
 
         cp = type(self).check_prerequisites()
         if cp is not True:
-            error_string = ("The bear " + type(self).__name__ +
+            error_string = ("The bear " + self.name +
                             " does not fulfill all requirements.")
             if cp is not False:
                 error_string += " " + cp
@@ -91,13 +91,13 @@ class Bear(Printer, LogPrinter):
                 self.get_metadata().create_params_from_section(self.section))
         except ValueError as err:
             self.warn("The bear {} cannot be executed.".format(
-                type(self).__name__), str(err))
+                self.name), str(err))
             return
 
         return self.run(*args, **kwargs)
 
     def execute(self, *args, **kwargs):
-        name = type(self).__name__
+        name = self.name
         try:
             self.debug("Running bear {}...".format(name))
             # If it's already a list it won't change it

--- a/coalib/collecting/Dependencies.py
+++ b/coalib/collecting/Dependencies.py
@@ -6,7 +6,7 @@ class CircularDependencyError(Exception):
         Creates the CircularDependencyError with a helpful message about the
         dependency.
         """
-        bear_names = [bear.__name__ for bear in bears]
+        bear_names = [bear.name for bear in bears]
 
         return cls("Circular dependency detected: " + " -> ".join(bear_names))
 

--- a/coalib/misc/Decorators.py
+++ b/coalib/misc/Decorators.py
@@ -298,3 +298,29 @@ def enforce_signature(function):
         return function(*args, **kwargs)
 
     return decorated
+
+
+class classproperty(property):
+    """
+    Decorator to set a class function to a class property.
+
+    Given a class like:
+
+    >>> class test:
+    ...     @classproperty
+    ...     def func(self):
+    ...         return 1
+
+    We can now access the class property using the class name:
+
+    >>> test.func
+    1
+
+    And we can still have the same behaviour with an instance:
+
+    >>> test().func
+    1
+    """
+
+    def __get__(self, obj, type_):
+        return self.fget.__get__(None, type_)(type_)

--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -634,7 +634,7 @@ def show_bear(console_printer, bear, sections, metadata):
     :param sections:        The sections to which the bear belongs.
     :param metadata:        Metadata about the bear.
     """
-    console_printer.print("{bear}:".format(bear=bear.__name__))
+    console_printer.print("{bear}:".format(bear=bear.name))
     console_printer.print("  " + metadata.desc + "\n")
 
     show_enumeration(console_printer,
@@ -667,12 +667,12 @@ def print_bears(console_printer, bears, compress):
     if not bears:
         console_printer.print("No bears to show.")
     elif compress:
-        bear_list = sorted(bears.keys(), key=lambda bear: bear.__name__)
+        bear_list = sorted(bears.keys(), key=lambda bear: bear.name)
         for bear in bear_list:
-            console_printer.print(" *", bear.__name__)
+            console_printer.print(" *", bear.name)
     else:
         for bear in sorted(bears.keys(),
-                           key=lambda bear: bear.__name__):
+                           key=lambda bear: bear.name):
             show_bear(console_printer,
                       bear,
                       bears[bear],

--- a/coalib/processes/BearRunning.py
+++ b/coalib/processes/BearRunning.py
@@ -136,7 +136,7 @@ def get_local_dependency_results(local_result_list, bear_instance):
                               results are picked.
     :param bear_instance:     The instance of a local bear to get the
                               dependencies from.
-    :return:                  Return none if their are no dependencies for the
+    :return:                  Return none if there are no dependencies for the
                               bear. Else return a dictionary containing
                               dependency results.
     """

--- a/coalib/processes/BearRunning.py
+++ b/coalib/processes/BearRunning.py
@@ -98,7 +98,7 @@ def run_bear(message_queue, timeout, bear_instance, *args, **kwargs):
     if kwargs.get("dependency_results", True) is None:
         del kwargs["dependency_results"]
 
-    name = bear_instance.__class__.__name__
+    name = bear_instance.name
 
     try:
         result_list = bear_instance.execute(*args, **kwargs)
@@ -363,7 +363,7 @@ def get_next_global_bear(timeout,
         if dependency_results is False:
             global_bear_queue.put(bear_id)
 
-    return bear, bear.__class__.__name__, dependency_results
+    return bear, dependency_results
 
 
 def task_done(obj):
@@ -450,11 +450,12 @@ def run_global_bears(message_queue,
     """
     try:
         while True:
-            bear, bearname, dep_results = (
+            bear, dep_results = (
                 get_next_global_bear(timeout,
                                      global_bear_queue,
                                      global_bear_list,
                                      global_result_dict))
+            bearname = bear.__class__.__name__
             result = run_global_bear(message_queue, timeout, bear, dep_results)
             if result:
                 global_result_dict[bearname] = result

--- a/coalib/settings/SectionFilling.py
+++ b/coalib/settings/SectionFilling.py
@@ -74,10 +74,10 @@ def fill_section(section, acquire_settings, log_printer, bears):
             needed = bear.get_non_optional_settings()
             for key in needed:
                 if key in prel_needed_settings:
-                    prel_needed_settings[key].append(bear.__name__)
+                    prel_needed_settings[key].append(bear.name)
                 else:
                     prel_needed_settings[key] = [needed[key][0],
-                                                 bear.__name__]
+                                                 bear.name]
 
     # Strip away existent settings.
     needed_settings = {}

--- a/docs/Users/Tutorials/Writing_Bears.rst
+++ b/docs/Users/Tutorials/Writing_Bears.rst
@@ -217,7 +217,7 @@ So let's see how you could tell *coala* which Bears to run before yours:
     class DependentBear(LocalBear):
 
         def run(self, filename, file, dependency_results):
-            results = dependency_results[OtherBear.__name__]
+            results = dependency_results[OtherBear.name]
 
         @staticmethod
         def get_dependencies():


### PR DESCRIPTION
Frequently, we need to use the name of the bear
inside the bear.
This should add the name() function which allows
users to just do self.name() easily.

Fixes https://github.com/coala-analyzer/coala/issues/1893