### PR TITLE
docs: Add example commit message for typos

### DIFF
--- a/docs/Getting_Involved/Writing_Good_Commits.rst
+++ b/docs/Getting_Involved/Writing_Good_Commits.rst
@@ -104,7 +104,7 @@ Example:
 
 Example
 ~~~~~~~
-
+Example 1:
 ::
 
     setup: Install .coafile via package_data
@@ -115,6 +115,15 @@ Example
     install it by itself.
 
     Fixes https://github.com/coala-analyzer/coala/issues/269
+
+Example 2:
+::
+
+    .travis.yml: Fix typo xontainer -> container
+
+    Fix a minor typo in the file for better readability.
+
+    Fixes https://github.com/coala-analyzer/coala/issues/xxx
 
 Why Do We Need Good Commits?
 ----------------------------


### PR DESCRIPTION
Add example commit message about typos in
newcomer page in docs.

Fixes https://github.com/coala-analyzer/coala/issues/1757