### PR TITLE
LineDiff: Raise ConflictError on conflict

### DIFF
--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -1,12 +1,8 @@
 import copy
 import difflib
 
-from coalib.results.LineDiff import LineDiff
+from coalib.results.LineDiff import LineDiff, ConflictError
 from coalib.results.SourceRange import SourceRange
-
-
-class ConflictError(Exception):
-    pass
 
 
 class Diff:

--- a/coalib/results/LineDiff.py
+++ b/coalib/results/LineDiff.py
@@ -3,6 +3,10 @@ import collections
 from coalib.misc.Decorators import generate_repr
 
 
+class ConflictError(Exception):
+    pass
+
+
 @generate_repr('change', 'delete', 'add_after')
 class LineDiff:
     """
@@ -40,8 +44,8 @@ class LineDiff:
             raise TypeError("change must be False or a tuple with an original "
                             "and a replacement string.")
         if value is not False and self.delete is not False:
-            raise AssertionError("A line cannot be changed and deleted "
-                                 "at the same time.")
+            raise ConflictError("A line cannot be changed and deleted "
+                                "at the same time.")
 
         self._change = value
 
@@ -54,8 +58,8 @@ class LineDiff:
         if not isinstance(value, bool):
             raise TypeError("delete can only be a boolean value.")
         if value is not False and self.change is not False:
-            raise AssertionError("A line cannot be changed and deleted "
-                                 "at the same time.")
+            raise ConflictError("A line cannot be changed and deleted "
+                                "at the same time.")
 
         self._delete = value
 

--- a/tests/results/DiffTest.py
+++ b/tests/results/DiffTest.py
@@ -36,7 +36,7 @@ class DiffTest(unittest.TestCase):
 
         self.uut.delete_line(1)
         # Line was deleted, unchangeable
-        self.assertRaises(AssertionError, self.uut.change_line, 1, "1", "2")
+        self.assertRaises(ConflictError, self.uut.change_line, 1, "1", "2")
 
     def test_affected_code(self):
         self.assertEqual(self.uut.affected_code("file"), [])

--- a/tests/results/LineDiffTest.py
+++ b/tests/results/LineDiffTest.py
@@ -1,6 +1,6 @@
 import unittest
 
-from coalib.results.LineDiff import LineDiff
+from coalib.results.LineDiff import LineDiff, ConflictError
 
 
 class LineDiffTest(unittest.TestCase):
@@ -11,7 +11,7 @@ class LineDiffTest(unittest.TestCase):
         self.assertRaises(TypeError, LineDiff, add_after=5)
         self.assertRaises(TypeError, LineDiff, change=True)
         self.assertRaises(TypeError, LineDiff, add_after=True)
-        self.assertRaises(AssertionError,
+        self.assertRaises(ConflictError,
                           LineDiff,
                           change=("1", "2"),
                           delete=True)
@@ -24,10 +24,10 @@ class LineDiffTest(unittest.TestCase):
 
         uut = LineDiff()
         uut.delete = True
-        self.assertRaises(AssertionError, setattr, uut, "change", ("1", "2"))
+        self.assertRaises(ConflictError, setattr, uut, "change", ("1", "2"))
         uut.delete = False
         uut.change = ("1", "2")
-        self.assertRaises(AssertionError, setattr, uut, "delete", True)
+        self.assertRaises(ConflictError, setattr, uut, "delete", True)
 
     def test_equality(self):
         self.assertEqual(LineDiff(), LineDiff())


### PR DESCRIPTION
AssertionError doesn't make sense.

Fixes https://github.com/coala-analyzer/coala/issues/1951