### PR TITLE
Section: Escape bear directories before globbing

### DIFF
--- a/coalib/settings/Section.py
+++ b/coalib/settings/Section.py
@@ -6,7 +6,8 @@ from collections import OrderedDict
 from coalib.collecting.Collectors import collect_registered_bears_dirs
 from coalib.misc.Decorators import enforce_signature, generate_repr
 from coalib.misc.DictUtilities import update_ordered_dict_key
-from coalib.settings.Setting import Setting, glob_list
+from coalib.settings.Setting import Setting, path_list
+from coalib.parsing.Globbing import glob_escape
 
 
 def append_to_sections(sections,
@@ -62,16 +63,16 @@ class Section:
         self.contents = OrderedDict()
 
     def bear_dirs(self):
-        bear_dirs = glob_list(self.get("bear_dirs", ""))
+        bear_dirs = path_list(self.get("bear_dirs", ""))
         for bear_dir in bear_dirs:
             sys.path.append(bear_dir)
-        bear_dirs = [
-            os.path.join(bear_dir, "**")
+        bear_dir_globs = [
+            os.path.join(glob_escape(bear_dir), "**")
             for bear_dir in bear_dirs]
-        bear_dirs += [
-            os.path.join(bear_dir, "**")
+        bear_dir_globs += [
+            os.path.join(glob_escape(bear_dir), "**")
             for bear_dir in collect_registered_bears_dirs('coalabears')]
-        return bear_dirs
+        return bear_dir_globs
 
     def is_enabled(self, targets):
         """

--- a/docs/Users/Tutorials/Writing_Bears.rst
+++ b/docs/Users/Tutorials/Writing_Bears.rst
@@ -57,6 +57,13 @@ to find it. We can do that with the ``-d`` (``--bear-dirs``) argument:
 
 ``coala -f src/*.c -d bears -b HelloWorldBear -L DEBUG``
 
+.. note::
+
+    The given bear directories must not have any glob expressions in them. Any
+    character that could be interpreted as a part of a glob expression will be
+    escaped. Please use comma separated values to give several such
+    directories instead.
+
 You should now see the debug message for our sample file.
 
 The Bear class also supports ``warn`` and ``err``.

--- a/tests/settings/SectionTest.py
+++ b/tests/settings/SectionTest.py
@@ -1,7 +1,10 @@
 import unittest
+import os
 
 from coalib.misc import Constants
 from coalib.settings.Section import Section, Setting, append_to_sections
+from coalib.settings.ConfigurationGathering import get_config_directory
+from coalib.parsing.Globbing import glob_escape
 
 
 class SectionTest(unittest.TestCase):
@@ -176,5 +179,9 @@ class SectionTest(unittest.TestCase):
     def test_bear_dirs(self):
         section = Section("section", None)
         empty_bear_dirs_len = len(section.bear_dirs())
-        section.append(Setting("bear_dirs", "test1, test2"))
+        section.append(Setting("bear_dirs", "test1, test2 (1)"))
         self.assertEqual(len(section.bear_dirs()), empty_bear_dirs_len + 2)
+        # Verify if bear directories are properly escaped
+        root = get_config_directory(section)
+        path = os.path.join(glob_escape(root), glob_escape("test2 (1)"), "**")
+        self.assertIn(path, section.bear_dirs())


### PR DESCRIPTION
To prevent misinterpretation of bear directories as glob expressions
we need to escape these characters. Also, we need to add real paths
to `sys.path` instead.
    
Introduced an extra assertion in tests to validate if bear directories
work as expected by having a directory with an unintended glob
expression.

Also mention that bear directories cannot be globs. Instead they
must be comma separated values.
    
Fixes https://github.com/coala-analyzer/coala/issues/1932
Fixes https://github.com/coala-analyzer/coala/issues/1831