### PR TITLE
ResultFilter: Add ensure_files_present method

### DIFF
--- a/coalib/results/ResultFilter.py
+++ b/coalib/results/ResultFilter.py
@@ -19,6 +19,7 @@ def filter_results(original_file_dict,
                                from all those that existed in the old changes
     """
 
+    ensure_files_present(original_file_dict, modified_file_dict)
     # diffs_dict[file] is a diff between the original and modified file
     diffs_dict = {}
     for file in original_file_dict:
@@ -205,3 +206,19 @@ def remove_result_ranges_diffs(result_list, file_dict):
         result_diff_dict_dict[original_result] = diff_dict
 
     return result_diff_dict_dict
+
+
+def ensure_files_present(original_file_dict, modified_file_dict):
+    """
+    Ensures that all files are available as keys in both dicts.
+
+    :param original_file_dict: Dict of lists of file contents before  changes
+    :param modified_file_dict: Dict of lists of file contents after changes
+    """
+    affected_files = set(original_file_dict.keys()).union(
+        set(modified_file_dict.keys()))
+    for file in affected_files:
+        if file not in original_file_dict:
+            original_file_dict[file] = []
+        if file not in modified_file_dict:
+            modified_file_dict[file] = []


### PR DESCRIPTION
This method ensures that deleted files and newly created files are
present in both dictionaries across coala runs. So that there are no
key errors.

Fixes: https://github.com/coala-analyzer/coala/issues/1866