### PR TITLE
Short URL for newcomer issues

### DIFF
--- a/docs/Getting_Involved/Newcomers.rst
+++ b/docs/Getting_Involved/Newcomers.rst
@@ -39,7 +39,7 @@ Start working
 -------------
 
 Now is the time to pick an issue.
-Here is the link that will lead you to `Newcomers issues <https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Acoala-analyzer+label%3Adifficulty%2Fnewcomer>`_.
+Here is the link that will lead you to `Newcomers issues <http://tinyurl.com/coala-new>`_.
 
 .. seealso::
 


### PR DESCRIPTION
Changed URL of newcomer issues in newcomer documentation from "http://coala.readthedocs.org/en/latest/Getting_Involved/Newcomers.html" to "http://tinyurl.com/coala-newcomer".

issue #1980 docs: Use tinyurl for newcomer issues in Newcomers docs