### PR TITLE
deps.nltk.sh: Add nltk_data installation in coala

### DIFF
--- a/.misc/appveyor.yml
+++ b/.misc/appveyor.yml
@@ -45,6 +45,11 @@ install:
   - "%CMD_IN_ENV% pip -q install --find-links=C:\\wheels -r test-requirements.txt"
   - "%CMD_IN_ENV% pip -q install --find-links=C:\\wheels -r requirements.txt"
   - "%CMD_IN_ENV% pip -q install --upgrade astroid"
+  # Download required nltk data
+  - "pip install nltk~=3.1.0"
+  - "python -m nltk.downloader punkt"
+  - "python -m nltk.downloader maxent_treebank_pos_tagger"
+  - "python -m nltk.downloader averaged_perceptron_tagger"
   # Calling setup.py will download checkstyle automatically so tests may succeed
   - "%CMD_IN_ENV% python setup.py --help"
 

--- a/.misc/deps.nltk.sh
+++ b/.misc/deps.nltk.sh
@@ -1,0 +1,18 @@
+set -e
+set -x
+
+
+NLTK_DATA_PATH=~/nltk_data
+
+function download_nltk_data {
+  pip install nltk~=3.1.0
+  python -m nltk.downloader punkt
+  python -m nltk.downloader maxent_treebank_pos_tagger
+  python -m nltk.downloader averaged_perceptron_tagger
+}
+
+if [ ! -d $NLTK_DATA_PATH ]; then
+  download_nltk_data
+else
+  echo "Using cached nltk data from $NLTK_DATA_PATH"
+fi

--- a/.misc/deps.osx.sh
+++ b/.misc/deps.osx.sh
@@ -27,3 +27,5 @@ pip install -U pip
 # Install packages with pip
 pip install -r test-requirements.txt
 pip install -r requirements.txt
+# Downloading nltk data that's required for nltk to run
+bash .misc/deps.nltk.sh

--- a/.misc/deps.sh
+++ b/.misc/deps.sh
@@ -24,6 +24,8 @@ for dep_version in "${dep_versions[@]}" ; do
 
   pip install -r test-requirements.txt
   pip install -r requirements.txt
+  # Downloading nltk data that's required for nltk to run
+  bash .misc/deps.nltk.sh
 
   cd .misc
   bash install.python-gi.sh

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,7 @@ dependencies:
     - ~/.pyenv/versions/3.3.6
     - ~/.pyenv/versions/3.4.3
     - ~/.pyenv/versions/3.5.1
+    - ~/nltk_data
   pre:
     - sed -i '/source \/home\/ubuntu\/virtualenvs\//d' ~/.circlerc
     - nvm alias default node


### PR DESCRIPTION
This commit fetches `nltk_data` so that imperative
mood test from `GitCommitBear` would work for coala.

Fixes https://github.com/coala-analyzer/coala/issues/2011