### PR TITLE
Processing: Provide ignoring without stop comment

### DIFF
--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -401,12 +401,14 @@ def yield_ignore_ranges(file_dict):
     for filename, file in file_dict.items():
         start = None
         bears = []
+        stop_ignoring = False
         for line_number, line in enumerate(file, start=1):
             line = line.lower()
             if "start ignoring " in line:
                 start = line_number
                 bears = get_ignore_scope(line, "start ignoring ")
             elif "stop ignoring" in line:
+                stop_ignoring = True
                 if start:
                     yield (bears,
                            SourceRange.from_values(filename,
@@ -421,6 +423,13 @@ def yield_ignore_ranges(file_dict):
                                                1,
                                                line_number+1,
                                                len(file[line_number])))
+        if stop_ignoring is False and start is not None:
+            yield (bears,
+                   SourceRange.from_values(filename,
+                                           start,
+                                           1,
+                                           len(file),
+                                           len(file[-1])))
 
 
 def process_queues(processes,

--- a/tests/processes/ProcessingTest.py
+++ b/tests/processes/ProcessingTest.py
@@ -413,6 +413,17 @@ class ProcessingTest(unittest.TestCase):
             self.assertEqual(test_source_range.end.line, 2)
             self.assertEqual(test_source_range.end.column, 42)
 
+        test_file_dict_d = {'f':
+                            ('# Start ignoring cBear\n',
+                             'All of this ignored\n')}
+        test_ignore_range_d = list(yield_ignore_ranges(test_file_dict_d))
+        for test_bears, test_source_range in test_ignore_range_d:
+            self.assertEqual(test_bears, ['cbear'])
+            self.assertEqual(test_source_range.start.line, 1)
+            self.assertEqual(test_source_range.start.column, 1)
+            self.assertEqual(test_source_range.end.line, 2)
+            self.assertEqual(test_source_range.end.column, 20)
+
 
 class ProcessingTest_GetDefaultActions(unittest.TestCase):
 


### PR DESCRIPTION
If a stop comment is not provided, the rest of the file from the
start comment will be ignored.

Fixes https://github.com/coala-analyzer/coala/issues/2003