### PR TITLE
ConsoleInteraction: Missing lang-spec in braces

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -641,8 +641,8 @@ def show_bear(console_printer, bear, sections, metadata):
                      "Supported languages:",
                      bear.LANGUAGES,
                      "  ",
-                     "The bear does not provide information about which "
-                     "languages it can analyze.")
+                     "(The bear does not provide information about which "
+                     "languages it can analyze.)")
     show_enumeration(console_printer,
                      "Used in:",
                      sections,

--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -618,8 +618,8 @@ some_file
             print_bears(self.log_printer.printer, bears, False)
             expected_string = "SomeBear:\n"
             expected_string += "  Some Description.\n\n"
-            expected_string += ("  The bear does not provide information "
-                                "about which languages it can analyze.\n\n")
+            expected_string += ("  (The bear does not provide information "
+                                "about which languages it can analyze.)\n\n")
             expected_string += "  Used in:\n"
             expected_string += "   * default\n\n"
             expected_string += "  No needed settings.\n\n"
@@ -633,8 +633,8 @@ some_file
             print_bears(self.log_printer.printer, bears, False)
             expected_string = "SomeOtherBear:\n"
             expected_string += "  This is a Bear.\n\n"
-            expected_string += ("  The bear does not provide information "
-                                "about which languages it can analyze.\n\n")
+            expected_string += ("  (The bear does not provide information "
+                                "about which languages it can analyze.)\n\n")
             expected_string += "  Used in:\n"
             expected_string += "   * test\n\n"
             expected_string += "  No needed settings.\n\n"
@@ -651,8 +651,8 @@ some_file
             print_bears(self.log_printer.printer, bears, False)
             expected_string = "TestBear2:\n"
             expected_string += "  Test bear 2 description.\n\n"
-            expected_string += ("  The bear does not provide information "
-                                "about which languages it can analyze.\n\n")
+            expected_string += ("  (The bear does not provide information "
+                                "about which languages it can analyze.)\n\n")
             expected_string += "  Used in:\n"
             expected_string += "   * test\n\n"
             expected_string += "  Needed Settings:\n"
@@ -667,8 +667,8 @@ some_file
             print_bears(self.log_printer.printer, bears, False)
             expected_string = "SomeBear:\n"
             expected_string += "  Some Description.\n\n"
-            expected_string += ("  The bear does not provide information "
-                                "about which languages it can analyze.\n\n")
+            expected_string += ("  (The bear does not provide information "
+                                "about which languages it can analyze.)\n\n")
             expected_string += "  No sections.\n\n"
             expected_string += "  No needed settings.\n\n"
             expected_string += "  No optional settings.\n\n"


### PR DESCRIPTION
If language specification is missing for a bear, the message is
displayed inside braces for better readability.