### PR TITLE
Linter: Accept non-matches when converting

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -253,7 +253,7 @@ def _create_linter(klass, options):
 
             for variable in ("line", "column", "end_line", "end_column"):
                 groups[variable] = (None
-                                    if groups.get(variable, "") == "" else
+                                    if groups.get(variable, None) is None else
                                     int(groups[variable]))
 
             if "origin" in groups:


### PR DESCRIPTION
If there's no match, groups.get will return None and not an empty string
which isn't int convertible.

CC @Makman2 for review