### PR TITLE
Linter: Allow `self` in `create_arguments`

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -197,7 +197,7 @@ def _create_linter(klass, options):
         def _get_create_arguments_metadata(cls):
             return FunctionMetadata.from_function(
                 cls.create_arguments,
-                omit={"filename", "file", "config_file"})
+                omit={"self", "filename", "file", "config_file"})
 
         @classmethod
         def _get_generate_config_metadata(cls):


### PR DESCRIPTION
So users are able to log stuff.