### PR TITLE
README.rst: Remove OS X build status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ meta information in `setup.py <setup.py>`__ for current maintainers.
 Project Status
 --------------
 
-|Linux Build Status| |Windows Build status| |OSX Build status|
+|Linux Build Status| |Windows Build status|
 
 |Scrutinizer Code Quality| |codecov.io|
 


### PR DESCRIPTION
OS X builds are no longer used.

Fixes https://github.com/coala-analyzer/coala/issues/2148