### PR TITLE
coala_main.py: Pass argparser to `run_coala`

### DIFF
--- a/coalib/coala_main.py
+++ b/coalib/coala_main.py
@@ -20,7 +20,8 @@ def run_coala(log_printer=None,
               acquire_settings=fail_acquire_settings,
               print_section_beginning=do_nothing,
               nothing_done=do_nothing,
-              autoapply=True):
+              autoapply=True,
+              arg_parser=None):
     """
     This is a main method that should be usable for almost all purposes and
     reduces executing coala to one function call.
@@ -59,7 +60,8 @@ def run_coala(log_printer=None,
         sections, local_bears, global_bears, targets = gather_configuration(
             acquire_settings,
             log_printer,
-            autoapply=autoapply)
+            autoapply=autoapply,
+            arg_parser=arg_parser)
 
         log_printer.debug("Platform {} -- Python {}, pip {}, coalib {}"
                           .format(platform.system(), platform.python_version(),

--- a/coalib/settings/ConfigurationGathering.py
+++ b/coalib/settings/ConfigurationGathering.py
@@ -103,7 +103,7 @@ def warn_nonexistent_targets(targets, sections, log_printer):
                 "Thus it cannot be executed.".format(section=target))
 
 
-def load_configuration(arg_list, log_printer):
+def load_configuration(arg_list, log_printer, arg_parser=None):
     """
     Parses the CLI args and loads the config file accordingly, taking
     default_coafile and the users .coarc into account.
@@ -114,7 +114,7 @@ def load_configuration(arg_list, log_printer):
                         dict(str, Section), targets: list(str)). (Types
                         indicated after colon.)
     """
-    cli_sections = parse_cli(arg_list=arg_list)
+    cli_sections = parse_cli(arg_list=arg_list, arg_parser=arg_parser)
     check_conflicts(cli_sections)
 
     if (
@@ -263,7 +263,8 @@ def get_config_directory(section):
 def gather_configuration(acquire_settings,
                          log_printer,
                          autoapply=None,
-                         arg_list=None):
+                         arg_list=None,
+                         arg_parser=None):
     """
     Loads all configuration files, retrieves bears and all needed
     settings, saves back if needed and warns about non-existent targets.
@@ -304,7 +305,7 @@ def gather_configuration(acquire_settings,
     # Note: arg_list can also be []. Hence we cannot use
     # `arg_list = arg_list or default_list`
     arg_list = sys.argv[1:] if arg_list is None else arg_list
-    sections, targets = load_configuration(arg_list, log_printer)
+    sections, targets = load_configuration(arg_list, log_printer, arg_parser)
     local_bears, global_bears = fill_settings(sections,
                                               acquire_settings,
                                               log_printer)


### PR DESCRIPTION
`parse_cli` already has an option to collect `arg_parser`
and use it at [coalib/parsing/CliParsing.py#L41](https://github.com/coala-analyzer/coala/blob/master/coalib/parsing/CliParsing.py#L41).
`run_coala` should essentially collect the argparser
as it's the main method for executing the coala for all
purpose. This would allow to create a wrapper around
`default_arg_parser` and use that for processing. Failing
to do so throws an error as coala don't recognise new arg
options that aren't available in default_arg_parse.
Reference at [coalib/parsing/CliParsing.py#L51](https://github.com/coala-analyzer/coala/blob/master/coalib/parsing/CliParsing.py#L51)

Fixes https://github.com/coala-analyzer/coala/issues/1914

CC @AbdealiJK  @sils1297  @Uran198 