### PR TITLE
Diff: Let split_diff return empty diffs

### DIFF
--- a/coalib/results/Diff.py
+++ b/coalib/results/Diff.py
@@ -303,6 +303,23 @@ class Diff:
 
         return result
 
+    def __bool__(self):
+        """
+        >>> bool(Diff([]))
+        False
+        >>> bool(Diff([], rename="some"))
+        True
+        >>> bool(Diff([], delete=True))
+        True
+        >>> bool(Diff.from_string_arrays(['1'], []))
+        True
+
+        :return: False if the patch has no effect at all when applied.
+        """
+        return (self.rename is not False or
+                self.delete is True or
+                len(self._changes) > 0)
+
     def delete_line(self, line_nr):
         """
         Mark the given line nr as deleted. The first line is line number 1.


### PR DESCRIPTION
Previously split_diff might not yield a diff at all for e.g. renamings.