### PR TITLE
Linter: Invoke full executable path

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,7 @@ test:
         parallel: true
     - pip install coala-bears colorama==0.3.6 --pre -U:
         parallel: true
+        timeout: 900  # Allow 15 mins
     - coala-ci -L DEBUG:
         parallel: true
     - bash .misc/deploy.coverage.sh:

--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -124,6 +124,10 @@ def _create_linter(klass, options):
 
     class LinterBase(LocalBear, metaclass=LinterMeta):
 
+        def __init__(self, *args, **kwargs):
+            LocalBear.__init__(self, *args, **kwargs)
+            self._full_executable_path = shutil.which(self.get_executable())
+
         @staticmethod
         def generate_config(filename, file):
             """
@@ -501,7 +505,7 @@ def _create_linter(klass, options):
                              "{!r} are not iterable.".format(args))
                     return
 
-                arguments = (self.get_executable(),) + args
+                arguments = (self._full_executable_path,) + args
                 self.debug("Running '{}'".format(' '.join(arguments)))
 
                 output = run_shell_command(


### PR DESCRIPTION
There are sometimes problems especially on Windows when batch files are
tried to be executed. Without the filename extension `subprocess.call`
fails.