### PR TITLE
Globbing: Fix glob for patterns with ** wildcard

### DIFF
--- a/coalib/parsing/Globbing.py
+++ b/coalib/parsing/Globbing.py
@@ -280,7 +280,10 @@ def relative_wildcard_glob(dirname, pattern):
     if not dirname:
         dirname = os.curdir
     try:
-        names = os.listdir(dirname)
+        if '**' in pattern:
+            names = list(_iter_relative_dirs(dirname))
+        else:
+            names = os.listdir(dirname)
     except OSError:
         return []
     result = []

--- a/tests/parsing/GlobbingTest.py
+++ b/tests/parsing/GlobbingTest.py
@@ -312,6 +312,12 @@ class GlobTest(unittest.TestCase):
                      TestFiles.dir2]
         self._test_glob(pattern, file_list)
 
+    def test_collect_recursive_part_of_basename(self):
+        pattern = os.path.join(TestFiles.glob_test_dir, "**.py")
+        file_list = [TestFiles.file11,
+                     TestFiles.file12]
+        self._test_glob(pattern, file_list)
+
     def test_collect_invalid(self):
         pattern = "NOPE"
         file_list = []


### PR DESCRIPTION
previously, when globbing for a pattern "/dir/**.xyz",
glob would check all files in dir with fnmatch(pattern).

It did not, however, recurse into sub directories and would
therefore miss matching files in those sub dirs. This commit
enables fnmatch matching against all those files when the
double-star wildcard is present in the pattern.