### PR TITLE
Change all instances of 'readthedocs.org' to 'readthedocs.io'.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ difficulty/newcomer -
 [newcomer issues](https://github.com/coala-analyzer/coala/issues?q=is%3Aissue+is%3Aopen+label%3Adifficulty%2Fnewcomer).
 
 Follow the instructions
-[here](http://coala.readthedocs.org/en/latest/Getting_Involved/README.html)
+[here](http://coala.readthedocs.io/en/latest/Getting_Involved/README.html)
 and get involved to help us make a better software.
 
 ## Filing Issues
@@ -49,7 +49,7 @@ For a PR to be merged, the following statements must hold true:
 - Commits shall comply to the commit guidelines as outlined in the docs.
 
 Commit guidelines can be found at the
-[Good Commits page](http://coala.readthedocs.org/en/latest/Getting_Involved/Writing_Good_Commits.html)
+[Good Commits page](http://coala.readthedocs.io/en/latest/Getting_Involved/Writing_Good_Commits.html)
 
 ## Correcting PRs
 

--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Newcomers Guide and Getting Involved
 ------------------------------------
 
 If you are new and would like to contribute, read our `Getting Involved Site
-<http://coala.readthedocs.org/en/latest/Getting_Involved/README.html>`__!
+<http://coala.readthedocs.io/en/latest/Getting_Involved/README.html>`__!
 
 We appreciate any help! Feel free to message us on
 `gitter <https://gitter.im/coala-analyzer/coala>`__. If you have any

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -132,7 +132,7 @@ New features:
 -  Actions that are not applicable multiple times are not shown after applying
    them anymore. (https://github.com/coala-analyzer/coala/issues/1064)
 -  Documentation about how to add coala as a pre commit hook has been added:
-   http://coala.readthedocs.org/en/latest/Users/Git_Hooks.html
+   http://coala.readthedocs.io/en/latest/Users/Git_Hooks.html
 -  Actions emit a success message now that is shown to the user and improves
    usability and intuitivity of actions.
 -  A warning is emitted if a bear or file glob does not match any bears or
@@ -208,7 +208,7 @@ For bear writers:
 Notable internal changes:
 
 -  API documentation is now available at
-   http://coala.readthedocs.org/en/latest/API/modules.html
+   http://coala.readthedocs.io/en/latest/API/modules.html
 -  coala switched to PyTest. Our old own framework is no longer maintained.
    (https://github.com/coala-analyzer/coala/issues/875)
 -  As always loads of refactorings to make the code more stable, readable and
@@ -345,7 +345,7 @@ This release features the following feature changes:
 -  Changed logging API in Bears (now: debug/warn/err).
 -  clang python bindings were added to the bearlib.
 -  Exitcodes were organized and documented.
-   (http://coala.readthedocs.org/en/latest/Users/Exit_Codes.html)
+   (http://coala.readthedocs.io/en/latest/Users/Exit_Codes.html)
 -  Handling of EOF/Keyboard Interrupt was improved.
 -  Console output is now colored.
 -  Bears can now easily convert settings to typed lists or dicts.
@@ -366,7 +366,7 @@ This release features the following feature changes:
 -  The StringProcessing libary is there to help bear writers deal with
    regexes and similar things.
 -  A new glob syntax was introduced and documented.
-   (http://coala.readthedocs.org/en/latest/Users/Glob_Patterns.html)
+   (http://coala.readthedocs.io/en/latest/Users/Glob_Patterns.html)
 -  The ``--apply-changes`` argument was removed as its concept does not
    fit anymore.
 -  Bears can now return any iterable. This makes it possible to

--- a/coalib/bearlib/abstractions/Lint.py
+++ b/coalib/bearlib/abstractions/Lint.py
@@ -43,7 +43,7 @@ class Lint(Bear):
     Deals with the creation of linting bears.
 
     For the tutorial see:
-    http://coala.readthedocs.org/en/latest/Users/Tutorials/Linter_Bears.html
+    http://coala.readthedocs.io/en/latest/Users/Tutorials/Linter_Bears.html
 
     :param executable:                  The executable to run the linter.
     :param prerequisite_command:        The command to run as a prerequisite

--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -622,7 +622,7 @@ def linter(executable: str,
     and after that inside ``process_output``.
 
     For the tutorial see:
-    http://coala.readthedocs.org/en/latest/Users/Tutorials/Linter_Bears.html
+    http://coala.readthedocs.io/en/latest/Users/Tutorials/Linter_Bears.html
 
     :param executable:
         The linter tool.

--- a/docs/Getting_Involved/Newcomers.rst
+++ b/docs/Getting_Involved/Newcomers.rst
@@ -44,7 +44,7 @@ Here is the link that will lead you to `Newcomers issues <http://tinyurl.com/coa
 
 .. seealso::
 
-    For more information about what bears are, please check the following link: `Writing bears <http://coala.readthedocs.org/en/latest/Users/Tutorials/Writing_Bears.html>`_
+    For more information about what bears are, please check the following link: `Writing bears <http://coala.readthedocs.io/en/latest/Users/Tutorials/Writing_Bears.html>`_
 
 The easy issues that will help you get started are labeled as
 "difficulty/newcomer" and are only there to give you a glimpse of how it is
@@ -54,12 +54,12 @@ Now pick an issue which isn't assigned, and if you want to fix
 it, then leave a comment that you would like to get assigned. This way
 we don't have multiple people working on the same issue at the same time.
 Now you can start working on it.
-For more info on how to work correctly with git, try `this <http://coala.readthedocs.org/en/latest/Users/Tutorials/Git_Help.html>`_.
+For more info on how to work correctly with git, try `this <http://coala.readthedocs.io/en/latest/Users/Tutorials/Git_Help.html>`_.
 
 .. note::
 
     Before starting to write your first commit, check out this link:
-    `Writing good commits <http://coala.readthedocs.org/en/latest/Getting_Involved/Writing_Good_Commits.html>`_
+    `Writing good commits <http://coala.readthedocs.io/en/latest/Getting_Involved/Writing_Good_Commits.html>`_
 
 Things to do before pushing
 ---------------------------
@@ -76,7 +76,7 @@ into your bash. This will analyze your code and help you fix it.
 
 .. seealso::
 
-    `Executing tests <http://coala.readthedocs.org/en/latest/Getting_Involved/Testing.html>`_
+    `Executing tests <http://coala.readthedocs.io/en/latest/Getting_Involved/Testing.html>`_
 
 Sending your changes
 --------------------
@@ -113,7 +113,7 @@ attempt - but don't worry, that's just how it works. It helps us maintain
 
 .. seealso::
 
-    `Review Process <http://coala.readthedocs.org/en/latest/Getting_Involved/Review.html>`_.
+    `Review Process <http://coala.readthedocs.io/en/latest/Getting_Involved/Review.html>`_.
 
 Now if you need to modify your code, you can simply edit it again, add it and
 commit it using
@@ -136,5 +136,5 @@ and send it. You have successfully edited your last commit!
     $ git push --force origin
 
 **Congratulations!** Your PR just got accepted! You're awesome.
-Now try `writing a bear <http://coala.readthedocs.org/en/latest/Users/Tutorials/Writing_Bears.html>`_,
+Now try `writing a bear <http://coala.readthedocs.io/en/latest/Users/Tutorials/Writing_Bears.html>`_,
 they are really rewarding!

--- a/docs/Users/Tutorials/Git_Help.rst
+++ b/docs/Users/Tutorials/Git_Help.rst
@@ -104,7 +104,7 @@ It will give you an idea about what files are currently modified.
     that contain the syntax.
 
 .. seealso::
-    For more information about tests, check `this link <http://coala.readthedocs.org/en/latest/Getting_Involved/Writing_Tests.html>`_.
+    For more information about tests, check `this link <http://coala.readthedocs.io/en/latest/Getting_Involved/Writing_Tests.html>`_.
 
 Adding the files and commiting
 ------------------------------
@@ -149,7 +149,7 @@ parts. They should have a newline between them.
 .. seealso::
 
   For more information about writing commit messages, check this
-  `link <http://coala.readthedocs.org/en/latest/Getting_Involved/Writing_Good_Commits.html>`_.
+  `link <http://coala.readthedocs.io/en/latest/Getting_Involved/Writing_Good_Commits.html>`_.
 
 Now that your message is written, you will have to save the file. Press escape
 to exit insert mode, and save the file (in Vim that is being done by pressing
@@ -185,7 +185,7 @@ You are awesome!
     to sync your local fork with the remote repository before sending
     a pull request.
 
-    More information regarding syncing can be found `here <http://coala.readthedocs.org/en/latest/Users/Tutorials/Git_Help.html#keeping-your-fork-in-sync>`_.
+    More information regarding syncing can be found `here <http://coala.readthedocs.io/en/latest/Users/Tutorials/Git_Help.html#keeping-your-fork-in-sync>`_.
 
 Follow-up
 ---------
@@ -206,7 +206,7 @@ don't worry that's just how it works. It helps us maintain *coala*
 
 .. seealso::
 
-     `Review Process <http://coala.readthedocs.org/en/latest/Getting_Involved/Review.html>`_.
+     `Review Process <http://coala.readthedocs.io/en/latest/Getting_Involved/Review.html>`_.
 
 Now if you need to modify your code, you can simply edit it again, add it and
 commit it using

--- a/docs/Users/Tutorials/Self_Correcting_Bears.rst
+++ b/docs/Users/Tutorials/Self_Correcting_Bears.rst
@@ -2,7 +2,7 @@ Bears That Can Suggest And Make Corrections
 -------------------------------------------
 
 **Note**: Go through the `Linter Bears
-<http://coala.readthedocs.org/en/latest/Users/Tutorials/Linter_Bears.html>`_
+<http://coala.readthedocs.io/en/latest/Users/Tutorials/Linter_Bears.html>`_
 before reading this.
 
 Some executables (like ``indent`` or ``autopep8``) can generate a corrected


### PR DESCRIPTION
As part of issue #2085.