### PR TITLE
Formatting: Fix description indentations

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -659,7 +659,7 @@ def show_bear(console_printer, bear, sections, metadata):
     :param metadata:        Metadata about the bear.
     """
     console_printer.print(bear.name + ":")
-    console_printer.print("  " + metadata.desc + "\n")
+    console_printer.print("  " + metadata.desc.replace("\n", "\n  ") + "\n")
 
     show_enumeration(
         console_printer, "Supported languages:",


### PR DESCRIPTION
Adds two spaces before description lines after the first
so that they all line up nicely

Fixes: https://github.com/coala-analyzer/coala/issues/2222