### PR TITLE
ConfigurationGatheringTest: Do not import bears

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,5 +2,6 @@ coverage==4.0.3
 pytest==2.8.7
 pytest-cov==2.2.1
 pytest-env==0.6.0
+pytest-mock==1.1
 pytest-timeout==1.0.0
 pytest-xdist==1.14

--- a/tests/settings/ConfigurationGatheringTest.py
+++ b/tests/settings/ConfigurationGatheringTest.py
@@ -5,6 +5,7 @@ import unittest
 
 from pyprint.ClosableObject import close_objects
 from pyprint.NullPrinter import NullPrinter
+import pytest
 
 from coalib.misc import Constants
 from coalib.misc.ContextManagers import make_temp, change_directory
@@ -14,6 +15,7 @@ from coalib.settings.ConfigurationGathering import (
     find_user_config, gather_configuration, load_configuration)
 
 
+@pytest.mark.usefixtures("disable_bears")
 class ConfigurationGatheringTest(unittest.TestCase):
 
     def setUp(self):

--- a/tests/settings/conftest.py
+++ b/tests/settings/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+import coalib.collecting.Collectors
+
+
+@pytest.fixture
+def disable_bears(mocker):
+    """
+    Disable all bears that would otherwise be found with `collect_bears(...)`.
+    """
+    mocker.patch.object(coalib.collecting.Collectors, '_import_bears',
+                        autospec=True, return_value=[])


### PR DESCRIPTION
Some of the ConfigurationGatheringTest test cases will fail if there are
any bears installed locally. To get around this for now we can simply
disable importing of all bears for this entire test suite.

Fixes https://github.com/coala-analyzer/coala/issues/2210