### PR TITLE
DefaultArgParser: Remove metavars

### DIFF
--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -13,6 +13,23 @@ except ImportError:
             pass
 
 
+class CustomFormatter(argparse.RawDescriptionHelpFormatter):
+    """
+    A Custom Formatter that will keep the metavars in the usage but remove them
+    in the more detailed arguments section.
+    """
+
+    def _format_action_invocation(self, action):
+        if not action.option_strings:
+            # For arguemnts that don't have options strings
+            metavar, = self._metavar_formatter(action, action.dest)(1)
+            return metavar
+        else:
+            # Option string arguments (like "-f, --files")
+            parts = action.option_strings
+            return ', '.join(parts)
+
+
 def default_arg_parser(formatter_class=None):
     """
     This function creates an ArgParser to parse command line arguments.
@@ -20,7 +37,7 @@ def default_arg_parser(formatter_class=None):
     :param formatter_class: Formatting the arg_parser output into a specific
                             form. For example: In the manpage format.
     """
-    formatter_class = formatter_class or argparse.RawDescriptionHelpFormatter
+    formatter_class = formatter_class or CustomFormatter
 
     entry_point = sys.argv[0]
     for entry in ['coala-ci', 'coala-dbus', 'coala-format', 'coala-json',

--- a/tests/parsing/DefaultArgParserTest.py
+++ b/tests/parsing/DefaultArgParserTest.py
@@ -1,0 +1,33 @@
+import argparse
+import re
+import unittest
+
+from coalib.parsing.DefaultArgParser import CustomFormatter
+
+
+class CustomFormatterTest(unittest.TestCase):
+
+    def setUp(self):
+        arg_parser = argparse.ArgumentParser(formatter_class=CustomFormatter)
+        arg_parser.add_argument('-a',
+                                '--all',
+                                nargs='?',
+                                const=True,
+                                metavar='BOOL')
+        arg_parser.add_argument('TARGETS',
+                                nargs='*')
+        self.output = arg_parser.format_help()
+
+    def test_metavar_in_usage(self):
+        match = re.search(r'usage:.+(-a \[BOOL\]).+\n\n',
+                          self.output,
+                          flags=re.DOTALL)
+        self.assertIsNotNone(match)
+        self.assertEquals(match.group(1), '-a [BOOL]')
+
+    def test_metavar_not_in_optional_args_sections(self):
+        match = re.search('optional arguments:.+(-a, --all).*',
+                          self.output,
+                          flags=re.DOTALL)
+        self.assertIsNotNone(match)
+        self.assertEquals(match.group(1), '-a, --all')


### PR DESCRIPTION
Changes the help output to remove the metavars from the long descriptions.
They are still kept in the usage section.

Fixes https://github.com/coala-analyzer/coala/issues/2228