### PR TITLE
Dev docs

### DIFF
--- a/docs/Getting_Involved/Newcomers.rst
+++ b/docs/Getting_Involved/Newcomers.rst
@@ -1,3 +1,5 @@
+.. _newcomer-guide:
+
 Welcome to the Newcomers guide!
 ===============================
 

--- a/docs/Users/Install.rst
+++ b/docs/Users/Install.rst
@@ -53,6 +53,8 @@ To install only *coala* (without any bears), you can do:
 With ``--pre`` you can install the nightly build of the *coala* base
 without bears.
 
+.. _venv-setup:
+
 Installing inside a virtualenv
 ------------------------------
 
@@ -95,55 +97,22 @@ virtualenv with:
 
 ::
 
-    $ pip3 install coala-bears
+    (venv)$ pip3 install coala-bears
 
 Installing coala from source
 ----------------------------
 
-In order to install *coala* from source, it is recommended to install git.
-See http://git-scm.com/ for further information and a downloadable
-installer or use your package manager on linux to get it.
+If you would like to develop coala, you should read our :ref:`dev-notes`
+section.
 
-.. note::
-
-    Again, here it is recommended to install *coala* inside a virtualenv.
-    This can be done by creating a virtualenv and running the installation
-    commands after the virtualenv has been activated.
-
-After having git installed, you can download the source code of *coala*
-with the following command:
+If you only desire to use the latest development version of coala, then you
+can run
 
 ::
 
-    $ git clone https://github.com/coala-analyzer/coala-bears/
-    $ cd coala-bears
+    (venv)$ pip3 install coala-bears --pre
 
-You can now install *coala* with a simple:
-
-::
-
-    $ python3 setup.py install
-
-For the above to work, you may also need to install `setuptools` which can be
-installed by running
-
-::
-
-    $ pip3 install setuptools
-
-You will have *coala* installed into your python scripts directory. On an
-unixoid system it is probably already available on your command line
-globally.
-
-You may also install a development version of *coala* to test and make
-changes easily. To do this run:
-
-::
-
-    $ python3 setup.py develop
-
-This essentially lets you install *coala* in a way that allows you to make
-changes to the code and see the changes take effect immediately.
+which will always install the most recent code from our master branch.
 
 Alternate installation
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/Users/Install.rst
+++ b/docs/Users/Install.rst
@@ -62,7 +62,8 @@ Virtualenv is probably what you want to use during development,
 you’ll probably want to use it there, too. You can read more about
 it at their documentation - http://virtualenv.readthedocs.org
 
-First, we need to install virtualenv to the system. This can be done
+First, we need to install virtualenv to the system. You may already have this
+installed as ``virtualenv`` or ``pyvenv``. If you do not, this can be done
 with ``pip3`` easily:
 
 ::
@@ -102,10 +103,10 @@ virtualenv with:
 Installing coala from source
 ----------------------------
 
-If you would like to develop coala, you should read our :ref:`dev-notes`
+If you would like to develop *coala*, you should read our :ref:`dev-notes`
 section.
 
-If you only desire to use the latest development version of coala, then you
+If you only desire to use the latest development version of *coala*, then you
 can run
 
 ::

--- a/docs/Users/Tutorials/Development_Setup.rst
+++ b/docs/Users/Tutorials/Development_Setup.rst
@@ -1,0 +1,66 @@
+.. _dev-notes:
+
+Development Setup Notes
+=======================
+
+The following are some useful notes for setting up an environment to work on
+coala.
+
+Virtualenv
+----------
+
+We highly recommend installing coala in a virtualenv for development. This
+will allow you to have a contained environment in which to modify coala,
+separate from any other installation of coala that you may not want to break.
+For more information about virtualenvs, please refer to the :ref:`virtualenv
+setup <venv-setup>` section for information on setting one up.
+
+Repositories
+------------
+
+If you are interested in contributing to coala, we recommend that you read our
+:ref:`newcomers' guide <newcomer-guide>` to familiarize yourself with our
+workflow, and perhaps with github itself.
+
+You will most likely need to work only in the ``coala`` or ``coala-bears``
+repository. The former is the core of coala, and the latter contains the set
+of standard bears. You can fork and clone the repositories from:
+
+https://github.com/coala-analyzer/coala
+https://github.com/coala-analyzer/coala-bears
+
+Installing from Git
+-------------------
+
+We recommend first installing the latest development snapshot of coala's
+master branch from and all of its dependencies with pip using
+
+::
+
+    (venv)$ pip3 install coala-bears --pre
+
+Then you can install a repository-backed version of the repository you would
+like to modify using
+
+::
+
+    (venv)$ pip3 install -e <path/to/clone>
+
+You will then be able to edit the repository and have the changes take effect
+in your virtualenv immediately. You will also be able to use pip to manage
+your installation of the package should you need to install from a different
+source in the future.
+
+
+Building Documentation
+----------------------
+
+You will need to install the following packages to build the documentation:
+
+::
+
+    (venv)$ pip3 install sphinx sphinx_rtd_theme
+
+Once you have done so, you can build the documentation by entering the docs
+directory and running ``make``. The documentation on the coala website is in
+the ``coala`` (not ``coala-bears``) repository.

--- a/docs/Users/Tutorials/Development_Setup.rst
+++ b/docs/Users/Tutorials/Development_Setup.rst
@@ -4,26 +4,27 @@ Development Setup Notes
 =======================
 
 The following are some useful notes for setting up an environment to work on
-coala.
+*coala*.
 
 Virtualenv
 ----------
 
-We highly recommend installing coala in a virtualenv for development. This
-will allow you to have a contained environment in which to modify coala,
-separate from any other installation of coala that you may not want to break.
-For more information about virtualenvs, please refer to the :ref:`virtualenv
-setup <venv-setup>` section for information on setting one up.
+We highly recommend installing *coala* in a virtualenv for development. This
+will allow you to have a contained environment in which to modify *coala*,
+separate from any other installation of *coala* that you may not want to
+break. For more information about virtualenvs, please refer to the
+:ref:`virtualenv setup <venv-setup>` section for information on setting one
+up.
 
 Repositories
 ------------
 
-If you are interested in contributing to coala, we recommend that you read our
-:ref:`newcomers' guide <newcomer-guide>` to familiarize yourself with our
+If you are interested in contributing to *coala*, we recommend that you read
+our :ref:`newcomers' guide <newcomer-guide>` to familiarize yourself with our
 workflow, and perhaps with github itself.
 
 You will most likely need to work only in the ``coala`` or ``coala-bears``
-repository. The former is the core of coala, and the latter contains the set
+repository. The former is the core of *coala*, and the latter contains the set
 of standard bears. You can fork and clone the repositories from:
 
 https://github.com/coala-analyzer/coala
@@ -32,7 +33,7 @@ https://github.com/coala-analyzer/coala-bears
 Installing from Git
 -------------------
 
-We recommend first installing the latest development snapshot of coala's
+We recommend first installing the latest development snapshot of *coala*'s
 master branch from and all of its dependencies with pip using
 
 ::
@@ -62,5 +63,5 @@ You will need to install the following packages to build the documentation:
     (venv)$ pip3 install sphinx sphinx_rtd_theme
 
 Once you have done so, you can build the documentation by entering the docs
-directory and running ``make``. The documentation on the coala website is in
+directory and running ``make``. The documentation on the *coala* website is in
 the ``coala`` (not ``coala-bears``) repository.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ Welcome to the coala documentation!
    Shell Autocompletion <Users/Tutorials/Shell_Autocompletion>
 
 .. toctree::
-   :caption: Developer Tutorials
+   :caption: Developer Resources
    :hidden:
 
    Development Setup <Users/Tutorials/Development_Setup>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ Welcome to the coala documentation!
    :caption: Developer Tutorials
    :hidden:
 
+   Development Setup <Users/Tutorials/Development_Setup>
    Writing Bears <Users/Tutorials/Writing_Bears>
    Testing Bears <Users/Tutorials/Testing_Bears>
    Linter Bears <Users/Tutorials/Linter_Bears>


### PR DESCRIPTION
* Move the development installation information from the main installation guide into a new set of development setup notes.
* Expand the instructions to describe why virtualenvs are needed.
* Use pip instead of setup.py to install from source.
* Clarify that --pre is sufficient for installing the newest code in master without making a repository clone.
* Add instructions for building documentation.
* Developer Tutorials -> Developer Resources
* Users may already have virtualenv or pyvenv.