### PR TITLE
ApplyPatchAction: Keep track of origs

### DIFF
--- a/coalib/coala_main.py
+++ b/coalib/coala_main.py
@@ -4,7 +4,7 @@ import platform
 import pip
 from pyprint.ConsolePrinter import ConsolePrinter
 
-from coalib import coala_delete_orig, VERSION
+from coalib import VERSION
 from coalib.misc.Exceptions import get_exitcode
 from coalib.output.Interactions import fail_acquire_settings
 from coalib.output.printers.LogPrinter import LogPrinter
@@ -75,9 +75,6 @@ def run_coala(log_printer=None,
         settings_hash = get_settings_hash(sections)
         flush_cache = bool(sections["default"].get("flush_cache", False) or
                            settings_changed(log_printer, settings_hash))
-
-        # Deleting all .orig files, so the latest files are up to date!
-        coala_delete_orig.main(log_printer, sections["default"])
 
         cache = FileCache(log_printer, os.getcwd(), flush_cache)
         for section_name, section in sections.items():

--- a/coalib/results/result_actions/ApplyPatchAction.py
+++ b/coalib/results/result_actions/ApplyPatchAction.py
@@ -46,11 +46,11 @@ class ApplyPatchAction(ResultAction):
             else:
                 file_diff_dict[filename] = result.diffs[filename]
 
-            # Backup original file, override old backup if needed
-            if (not no_orig and
-                    isfile(pre_patch_filename) and
-                    not isfile(pre_patch_filename + ".orig")):
-                shutil.copy2(pre_patch_filename, pre_patch_filename + ".orig")
+                # Backup original file, only if there was no previous patch
+                # from this run though!
+                if not no_orig and isfile(pre_patch_filename):
+                    shutil.copy2(pre_patch_filename,
+                                 pre_patch_filename + ".orig")
 
             diff = file_diff_dict[filename]
             if diff.delete or diff.rename:

--- a/tests/coalaCITest.py
+++ b/tests/coalaCITest.py
@@ -2,10 +2,9 @@ import os
 import re
 import sys
 import unittest
-from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from coalib import coala_ci
-from coalib.misc.ContextManagers import make_temp, prepare_file
+from coalib.misc.ContextManagers import prepare_file
 from tests.TestUtilities import bear_test_module, execute_coala
 
 
@@ -72,17 +71,3 @@ class coalaCITest(unittest.TestCase):
                                            "-b", 'SpaceConsistencyTestBear',
                                            '-c', os.devnull)
             self.assertIn("During execution, we found that some", output)
-
-    def test_coala_delete_orig(self):
-        with TemporaryDirectory() as tempdir,\
-             NamedTemporaryFile(suffix='.orig',
-                                dir=tempdir,
-                                delete=False) as orig_file,\
-             make_temp(suffix='.coafile', prefix='', dir=tempdir) as coafile,\
-             make_temp(dir=tempdir) as unrelated_file:
-            orig_file.close()
-
-            execute_coala(coala_ci.main, "coala-ci", "-S",
-                          "project_dir=" + os.path.dirname(coafile))
-            self.assertFalse(os.path.isfile(orig_file.name))
-            self.assertTrue(os.path.isfile(unrelated_file))

--- a/tests/results/result_actions/ApplyPatchActionTest.py
+++ b/tests/results/result_actions/ApplyPatchActionTest.py
@@ -113,7 +113,7 @@ class ApplyPatchActionTest(unittest.TestCase):
             uut.apply(Result("origin", "msg", diffs={f_a: diff}),
                       file_dict,
                       file_diff_dict)
-            self.assertTrue(isfile(f_a+".renamed.orig"))
+            self.assertFalse(isfile(f_a+".renamed.orig"))
 
             file_dict = {f_a+".renamed": open(f_a+".renamed").readlines()}
 


### PR DESCRIPTION
There's no need to crawl *every directory* every time for origs. This is
probably a huge performance hit on HDDs.