### PR TITLE
linter: Don't show executable name automatically

### DIFF
--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -235,10 +235,7 @@ def _create_linter(klass, options):
                 cls._get_process_output_metadata(),
                 cls._get_generate_config_metadata(),
                 cls._get_create_arguments_metadata())
-            merged_metadata.desc = (
-                "{}\n\nThis bear uses the {!r} tool.".format(
-                    inspect.getdoc(cls), cls.get_executable()))
-
+            merged_metadata.desc = inspect.getdoc(cls)
             return merged_metadata
 
         def _convert_output_regex_match_to_result(self,


### PR DESCRIPTION
This is not that useful, the bear writer should rather provide a URL for
more information manually, which is already done for most linter bears
anyway.

This reverts commit 60495403c9261f3ea8158213d5bf1330a6eb9b48.