### PR TITLE
GemRequirement: Add require attribute

### DIFF
--- a/coalib/bears/requirements/GemRequirement.py
+++ b/coalib/bears/requirements/GemRequirement.py
@@ -7,20 +7,25 @@ class GemRequirement(PackageRequirement):
     requirements from ``gem``, without using the manager name.
     """
 
-    def __init__(self, package, version=""):
+    def __init__(self, package, version="", require=""):
         """
         Constructs a new ``GemRequirement``, using the ``PackageRequirement``
         constructor.
 
-        >>> pr = GemRequirement('setuptools', '19.2')
+        >>> pr = GemRequirement('setuptools', '19.2', 'flag')
         >>> pr.manager
         'gem'
         >>> pr.package
         'setuptools'
         >>> pr.version
         '19.2'
+        >>> pr.require
+        'flag'
 
         :param package: A string with the name of the package to be installed.
         :param version: A version string. Leave empty to specify latest version.
+        :param require: A string that specifies any additional flags, that
+                        would be used with ``require``.
         """
         PackageRequirement.__init__(self, 'gem', package, version)
+        self.require = require


### PR DESCRIPTION
This attribute is by default empty, and
can be specified if any flags are to be
used upon installation.