### PR TITLE
StringConverter: Inline default argument of `list_delimiters` into function using a tuple

### DIFF
--- a/coalib/misc/StringConverter.py
+++ b/coalib/misc/StringConverter.py
@@ -16,11 +16,9 @@ class StringConverter:
     def __init__(self,
                  value,
                  strip_whitespaces=True,
-                 list_delimiters=None,
+                 list_delimiters=(',', ';'),
                  dict_delimiter=":",
                  remove_empty_iter_elements=True):
-        if list_delimiters is None:
-            list_delimiters = [",", ";"]
 
         if not isinstance(list_delimiters, Iterable):
             raise TypeError("list_delimiters has to be an Iterable.")


### PR DESCRIPTION
Changed default arg into function using tuple

Fixes<https://github.com/coala-analyzer/coala/issues/2376>