### PR TITLE
Syntax highlighting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyPrint>=0.2.4,==0.2.*
+Pygments>=2.1.3
 setuptools>=19.2
 # Do *not* use 0.3 which is not backwards compatible to common clang versions
 libclang-py3==0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ setuptools>=19.2
 # Do *not* use 0.3 which is not backwards compatible to common clang versions
 libclang-py3==0.2
 appdirs==1.4.*
-coala_decorators>=0.2.1,==0.2.*
+coala_utils~=0.4.8


### PR DESCRIPTION
Need help
So I am trying to bring in syntax highlighting for the output lines. I am able to get the basic thing done but it's without the dots and also I am unsure on where to place this thing. Currently, I have placed it [here]( https://github.com/coala-analyzer/coala/blob/master/coalib/output/ConsoleInteraction.py#L165)

`print(highlight(line, PythonLexer(), TerminalFormatter()))`

Python Lexer highlights the line. I'll make a more generic version where lexer will be detected by which language is it by taking that from bear property. But before going that step, I want to get this thing correct.

So I want to know which function should I replace with my custom print function?

Because right now, you can see the 2 outputs I want my syntax highlighted version with the dots (i.e. basically remove the function which uses red or blue color highlights)

![screenshot from 2016-07-02 13-44-36](https://cloud.githubusercontent.com/assets/5689132/16539964/0cfbec30-4071-11e6-8c03-1f8bf8b981f9.png)
