### PR TITLE
GoRequirement: Add installation methods

### DIFF
--- a/coalib/bears/requirements/GoRequirement.py
+++ b/coalib/bears/requirements/GoRequirement.py
@@ -1,4 +1,5 @@
 from coalib.bears.requirements.PackageRequirement import PackageRequirement
+from coalib.misc.Shell import call_without_output
 
 
 class GoRequirement(PackageRequirement):
@@ -29,3 +30,23 @@ class GoRequirement(PackageRequirement):
         """
         PackageRequirement.__init__(self, 'go', package, version)
         self.flag = flag
+
+    def install_command(self):
+        """
+        Creates the installation command for the instance of the class.
+
+        >>> GoRequirement(
+        ...     'github.com/golang/lint/golint', '' , '-u' ).install_command()
+        'go get -u github.com/golang/lint/golint'
+
+        :param return: A string with the installation command.
+        """
+        return "go get {} {}".format(self.flag, self.package)
+
+    def is_installed(self):
+        """
+        Checks if the dependency is installed.
+
+        :param return: True if dependency is installed, false otherwise.
+        """
+        return not call_without_output(('go', 'doc', self.package))

--- a/tests/bears/requirements/GoRequirementTest.py
+++ b/tests/bears/requirements/GoRequirementTest.py
@@ -1,0 +1,13 @@
+import unittest
+import shutil
+from coalib.bears.requirements.GoRequirement import GoRequirement
+
+
+@unittest.skipIf(shutil.which('go') is None, "Go is not installed.")
+class GoRequirementTestCase(unittest.TestCase):
+
+    def test_installed_requirement(self):
+        self.assertTrue(GoRequirement('go').is_installed())
+
+    def test_not_installed_requirement(self):
+        self.assertFalse(GoRequirement('some_bad_package').is_installed())


### PR DESCRIPTION
The install_command method builds the command from its Go attribute.

The is_installed method checks whether Go is installed or not.

Fixes https://github.com/coala-analyzer/coala/issues/2398