### PR TITLE
coala.py: Provide json output for showing bears.

### DIFF
--- a/coalib/coala.py
+++ b/coalib/coala.py
@@ -27,6 +27,34 @@ from coalib.parsing.DefaultArgParser import default_arg_parser
 from coalib.settings.ConfigurationGathering import load_configuration
 
 
+def display_bears(args,
+                  log_printer,
+                  console_printer=ConsolePrinter(),
+                  show_json=False):
+    """
+    Display the bears.
+    :param is_json: True for coala-json else False.
+    """
+    sections, _ = load_configuration(arg_list=None,
+                                     log_printer=log_printer)
+    local_bears, global_bears = collect_all_bears_from_sections(
+        sections, log_printer)
+    if args.filter_by_language:
+        local_bears = filter_section_bears_by_languages(
+            local_bears, args.filter_by_language)
+        global_bears = filter_section_bears_by_languages(
+            global_bears, args.filter_by_language)
+
+    show_bears_data = show_bears(local_bears,
+                                 global_bears,
+                                 args.show_description or args.show_details,
+                                 args.show_details,
+                                 console_printer,
+                                 show_json)
+    if show_json:
+        return show_bears_data
+
+
 def main():
     try:
         console_printer = ConsolePrinter()
@@ -36,21 +64,9 @@ def main():
         args = default_arg_parser().parse_args()
 
         if args.show_bears:
-            sections, _ = load_configuration(arg_list=None,
-                                             log_printer=log_printer)
-            local_bears, global_bears = collect_all_bears_from_sections(
-                sections, log_printer)
-            if args.filter_by_language:
-                local_bears = filter_section_bears_by_languages(
-                    local_bears, args.filter_by_language)
-                global_bears = filter_section_bears_by_languages(
-                    global_bears, args.filter_by_language)
-
-            show_bears(local_bears,
-                       global_bears,
-                       args.show_description or args.show_details,
-                       args.show_details,
-                       console_printer)
+            display_bears(args,
+                          log_printer,
+                          console_printer)
             return 0
     except BaseException as exception:  # pylint: disable=broad-except
         return get_exitcode(exception, log_printer)

--- a/coalib/coala_json.py
+++ b/coalib/coala_json.py
@@ -13,6 +13,7 @@
 
 import json
 
+from coalib.coala import display_bears
 from coalib.coala_main import run_coala
 from coalib.output.JSONEncoder import create_json_encoder
 from coalib.output.printers.ListLogPrinter import ListLogPrinter
@@ -28,12 +29,34 @@ def main():
     args = arg_parser.parse_args()
 
     log_printer = None if args.text_logs else ListLogPrinter()
+    JSONEncoder = create_json_encoder(use_relpath=args.relpath)
+
+    if args.show_bears:
+        results = display_bears(args=args,
+                                log_printer=log_printer,
+                                show_json=True)
+        retval = {"results": results}
+        if args.output:
+            filename = str(args.output[0])
+            with open(filename, 'w+') as fp:
+                json.dump(retval, fp,
+                          cls=JSONEncoder,
+                          sort_keys=True,
+                          indent=2,
+                          separators=(',', ': '))
+        else:
+            print(json.dumps(retval,
+                             cls=JSONEncoder,
+                             sort_keys=True,
+                             indent=2,
+                             separators=(',', ': ')))
+        return 0
+
     results, exitcode, _ = run_coala(log_printer=log_printer, autoapply=False)
 
     retval = {"results": results}
     if not args.text_logs:
         retval["logs"] = log_printer.logs
-    JSONEncoder = create_json_encoder(use_relpath=args.relpath)
     if args.output:
         filename = str(args.output[0])
         with open(filename, 'w+') as fp:

--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -653,7 +653,8 @@ def show_bear(bear,
               sections,
               show_description,
               show_params,
-              console_printer):
+              console_printer,
+              show_json):
     """
     Display all information about a bear.
 
@@ -662,7 +663,30 @@ def show_bear(bear,
     :param show_description: True if the main description should be shown.
     :param show_params:      True if the details should be shown.
     :param console_printer:  Object to print messages on the console.
+    :param show_json:        True if console output is a json else False.
+    :return:                 A json data if `show_json` is True
     """
+    if show_json:
+        bear_json_data = {'name': '',
+                          'description': '',
+                          'params': ''}
+
+        bear_json_data['name'] = bear.name
+
+        if show_description or show_params:
+            metadata = bear.get_metadata()
+            if show_description:
+                bear_json_data['description'] = metadata.desc
+            if show_params:
+                bear_json_data['params'] = {'Llnguages': bear.LANGUAGES,
+                                            'use': sections,
+                                            'needed settings':
+                                            metadata.non_optional_params,
+                                            'optional settings':
+                                            metadata.optional_params}
+
+        return bear_json_data
+
     console_printer.print(bear.name, color="blue")
 
     if not show_description and not show_params:
@@ -702,7 +726,8 @@ def show_bear(bear,
 def print_bears(bears,
                 show_description,
                 show_params,
-                console_printer):
+                console_printer,
+                show_json):
     """
     Presents all bears being used in a stylized manner.
 
@@ -713,27 +738,41 @@ def print_bears(bears,
     :param show_params:      True if the parameters and their description
                              should be shown.
     :param console_printer:  Object to print messages on the console.
+    :param show_json:        True if console output is a json else False.
+    :return:                 A list of json data if `show_json` is True.
     """
     if not bears:
         console_printer.print("No bears to show. Did you forget to install "
                               "the `coala-bears` package? Try `pip3 install "
                               "coala-bears`.")
         return
-
+    bear_json_list = []
     for bear, sections in sorted(bears.items(),
                                  key=lambda bear_tuple: bear_tuple[0].name):
-        show_bear(bear,
-                  sections,
-                  show_description,
-                  show_params,
-                  console_printer)
+        if show_json:
+            bear_json_list.append(show_bear(bear,
+                                            sections,
+                                            show_description,
+                                            show_params,
+                                            console_printer,
+                                            show_json))
+        else:
+            show_bear(bear,
+                      sections,
+                      show_description,
+                      show_params,
+                      console_printer,
+                      show_json)
+    if show_json:
+        return bear_json_list
 
 
 def show_bears(local_bears,
                global_bears,
                show_description,
                show_params,
-               console_printer):
+               console_printer,
+               show_json=False):
     """
     Extracts all the bears from each enabled section or the sections in the
     targets and passes a dictionary to the show_bears_callback method.
@@ -747,7 +786,12 @@ def show_bears(local_bears,
     :param show_params:      True if the parameters and their description
                              should be shown.
     :param console_printer:  Object to print messages on the console.
+    :param show_json:        True if the console output is json
+    else False.
+    :return:                 A list of json data if `show_json` is True.
     """
     bears = inverse_dicts(local_bears, global_bears)
-
-    print_bears(bears, show_description, show_params, console_printer)
+    print_bears_data = print_bears(bears, show_description, show_params,
+                                   console_printer, show_json)
+    if show_json:
+        return print_bears_data

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -159,8 +159,8 @@ coala can also automatically fix your code:
         choices=('INFO', 'NORMAL', 'MAJOR'), metavar='ENUM',
         help="set minimal result severity to INFO/NORMAL/MAJOR")
 
-    # The following are "coala" specific arguments
-    if parser_type == 'coala':
+    # The following are "coala" and "coala-json" specific arguments
+    if parser_type == 'coala' or parser_type == 'coala-json':
         outputs_group.add_argument(
             '-B', '--show-bears', const=True, action='store_const',
             help='list all bears')


### PR DESCRIPTION
This commit adds an option to show bears, filter by
languages to coala-json. Previously it was limited to
coala only.

Note: I will also write tests if if feature request is approved. :)
Closes https://github.com/coala-analyzer/coala/issues/2439