### PR TITLE
ConsoleInteraction: Fix empty line tab display

### DIFF
--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -184,7 +184,7 @@ def print_lines(console_printer,
 
             print_spaces_tabs_in_unicode(
                 console_printer, line[sourcerange.end.column-1:],
-                tab_dict, FILE_LINES_COLOR, sourcerange.end.column)
+                tab_dict, FILE_LINES_COLOR, sourcerange.end.column-1)
             console_printer.print("")
         else:
             print_spaces_tabs_in_unicode(

--- a/tests/output/ConsoleInteractionTest.py
+++ b/tests/output/ConsoleInteractionTest.py
@@ -526,7 +526,7 @@ Project wide:
                                               file="file",
                                               line=2)],
                           {abspath("file"): ["test line\n",
-                                             "line 2\n",
+                                             "\t\n",
                                              "line 3\n",
                                              "line 4\n",
                                              "line 5\t\n"]},
@@ -535,7 +535,7 @@ Project wide:
 
             self.assertEqual("""
 file
-|   2| line•2
+|   2| --->
 |    | [NORMAL] SpaceConsistencyBear:
 |    | Trailing whitespace found
 


### PR DESCRIPTION
When there is just one tab in one line, it throws an error because
it cant find the sourcerange end. This corrects it by decreasing
the sourcerange column end by 1.

Fixes https://github.com/coala-analyzer/coala/issues/2180