### PR TITLE
DictUtilities.py: Fix incorrect example in docstring

### DIFF
--- a/coalib/misc/DictUtilities.py
+++ b/coalib/misc/DictUtilities.py
@@ -4,8 +4,8 @@ from collections import Iterable, OrderedDict
 def inverse_dicts(*dicts):
     """
     Inverts the dicts, e.g. {1: 2, 3: 4} and {2: 3, 4: 4} will be inverted
-    {2: [1, 2], 4: [3, 4]}. This also handles dictionaries with Iterable items
-    as values e.g. {1: [1, 2, 3], 2: [3, 4, 5]} and
+    {2: [1], 3: [2], 4: [3, 4]}. This also handles dictionaries
+    with Iterable items as values e.g. {1: [1, 2, 3], 2: [3, 4, 5]} and
     {2: [1], 3: [2], 4: [3, 4]} will be inverted to
     {1: [1, 2], 2: [1, 3], 3: [1, 2, 4], 4: [2, 4], 5: [2]}.
     No order is preserved.


### PR DESCRIPTION
Change the result of inverse_dict to the correct value

Fixes https://github.com/coala-analyzer/coala/issues/2438