### PR TITLE
Remove diffs from auto-generated ordering in Result

### DIFF
--- a/coalib/results/Result.py
+++ b/coalib/results/Result.py
@@ -20,8 +20,7 @@ from coalib.results.SourceRange import SourceRange
                    "origin",
                    "message",
                    "additional_info",
-                   "debug_msg",
-                   "diffs")
+                   "debug_msg")
 class Result:
     """
     A result is anything that has an origin and a message.


### PR DESCRIPTION
Until we have a proper deterministic ordering, non-deterministic ordering is better than no coala at all.