### PR TITLE
coala_main.py: Pass `arg_list` to run_coala params

### DIFF
--- a/coalib/coala_main.py
+++ b/coalib/coala_main.py
@@ -24,7 +24,8 @@ def run_coala(log_printer=None,
               print_section_beginning=do_nothing,
               nothing_done=do_nothing,
               autoapply=True,
-              arg_parser=None):
+              arg_parser=None,
+              arg_list=None):
     """
     This is a main method that should be usable for almost all purposes and
     reduces executing coala to one function call.
@@ -49,6 +50,7 @@ def run_coala(log_printer=None,
     :param autoapply:               Set to False to autoapply nothing by
                                     default; this is overridable via any
                                     configuration file/CLI.
+    :param arg_list:                The CLI argument list.
     :return:                        A dictionary containing a list of results
                                     for all analyzed sections as key.
     """
@@ -64,7 +66,8 @@ def run_coala(log_printer=None,
             acquire_settings,
             log_printer,
             autoapply=autoapply,
-            arg_parser=arg_parser)
+            arg_parser=arg_parser,
+            arg_list=arg_list)
 
         log_printer.debug("Platform {} -- Python {}, pip {}, coalib {}"
                           .format(platform.system(), platform.python_version(),


### PR DESCRIPTION
Adding `arg_list` to `run_coala` provides control over
argument list for the APIs that uses `run_coala` to run
coala. For example: coala-html uses `run_coala` and requires some modification
in `arg_list` which isn't possible without exposing arg_list from run_coala

CC @sils1297 @Uran198 