### PR TITLE
Add a link to bears-doc in the `Sections` section.

### DIFF
--- a/docs/Users/Tutorials/Tutorial.rst
+++ b/docs/Users/Tutorials/Tutorial.rst
@@ -162,6 +162,12 @@ As you see, sections provide a way to have different configurations for
 possibly different languages in one file. They are executed
 sequentially.
 
+.. note::
+
+    For a list of configuration options for the bears, take a look at our
+    `bear-docs <https://github.com/coala-analyzer/bear-docs>`_ documentation.
+
+
 Auto-applying results
 ---------------------
 


### PR DESCRIPTION
I was missing this link when reading the tutorial. So this is a proposal to add a link to bears-doc in the tutorial where the `.coafile` sections are explained.