### PR TITLE
Processing: Use the right line for ignore range

### DIFF
--- a/coalib/processes/Processing.py
+++ b/coalib/processes/Processing.py
@@ -452,12 +452,13 @@ def yield_ignore_ranges(file_dict):
                                    line_number,
                                    len(file[line_number-1])))
                 elif "ignore " in line:
+                    end_line = min(line_number + 1, len(file))
                     yield (get_ignore_scope(line, "ignore "),
-                           SourceRange.from_values(filename,
-                                                   line_number,
-                                                   1,
-                                                   line_number+1,
-                                                   len(file[line_number])))
+                           SourceRange.from_values(
+                               filename,
+                               line_number, 1,
+                               end_line, len(file[end_line - 1])))
+
         if stop_ignoring is False and start is not None:
             yield (bears,
                    SourceRange.from_values(filename,

--- a/tests/processes/ProcessingTest.py
+++ b/tests/processes/ProcessingTest.py
@@ -433,6 +433,19 @@ class ProcessingTest(unittest.TestCase):
             self.assertEqual(test_source_range.end.line, 2)
             self.assertEqual(test_source_range.end.column, 20)
 
+        # This case was a bug.
+        test_file_dict_single_line = {'f': ('# ignore XBEAR',)}
+        test_ignore_range_single_line = list(yield_ignore_ranges(
+            test_file_dict_single_line))
+
+        self.assertEqual(len(test_ignore_range_single_line), 1)
+        bears, source_range = test_ignore_range_single_line[0]
+        self.assertEqual(bears, ['xbear'])
+        self.assertEqual(source_range.start.line, 1)
+        self.assertEqual(source_range.start.column, 1)
+        self.assertEqual(source_range.end.line, 1)
+        self.assertEqual(source_range.end.column, 14)
+
 
 class ProcessingTest_GetDefaultActions(unittest.TestCase):
 


### PR DESCRIPTION
~~As the enumeration starts with 1 and addressing of lists is zero-based,
we need to decrement the `line_number`.~~