### PR TITLE
Replace or with inline if and vice-versa

### DIFF
--- a/coalib/bearlib/abstractions/ExternalBearWrap.py
+++ b/coalib/bearlib/abstractions/ExternalBearWrap.py
@@ -197,7 +197,7 @@ def _create_wrapper(klass, options):
             return self.parse_output(out, filename)
 
     result_klass = type(klass.__name__, (klass, ExternalBearWrapBase), {})
-    result_klass.__doc__ = klass.__doc__ if klass.__doc__ else ""
+    result_klass.__doc__ = klass.__doc__ or ""
     return result_klass
 
 

--- a/coalib/bearlib/abstractions/Linter.py
+++ b/coalib/bearlib/abstractions/Linter.py
@@ -525,7 +525,7 @@ def _create_linter(klass, options):
     # `create_arguments` and other methods would be overridden by the
     # default version.
     result_klass = type(klass.__name__, (klass, LinterBase), {})
-    result_klass.__doc__ = klass.__doc__ if klass.__doc__ else ""
+    result_klass.__doc__ = klass.__doc__ or ""
     return result_klass
 
 

--- a/coalib/bears/Bear.py
+++ b/coalib/bears/Bear.py
@@ -231,7 +231,8 @@ class Bear(Printer, LogPrinter):
         try:
             self.debug("Running bear {}...".format(name))
             # If it's already a list it won't change it
-            return list(self.run_bear_from_section(args, kwargs) or [])
+            result = self.run_bear_from_section(args, kwargs)
+            return [] if result is None else list(result)
         except:
             self.warn(
                 "Bear {} failed to run. Take a look at debug messages (`-L "

--- a/coalib/coala_delete_orig.py
+++ b/coalib/coala_delete_orig.py
@@ -11,7 +11,8 @@ from coalib.parsing.Globbing import glob_escape
 
 def main(log_printer=None, section: Section=None):
     start_path = get_config_directory(section)
-    log_printer = log_printer or LogPrinter(ConsolePrinter())
+    log_printer = (LogPrinter(ConsolePrinter()) if log_printer is None
+                   else log_printer)
 
     if start_path is None:
         return 255

--- a/coalib/coala_main.py
+++ b/coalib/coala_main.py
@@ -54,7 +54,9 @@ def run_coala(log_printer=None,
     :return:                        A dictionary containing a list of results
                                     for all analyzed sections as key.
     """
-    log_printer = log_printer or LogPrinter(ConsolePrinter(), LOG_LEVEL.DEBUG)
+    log_printer = (
+        LogPrinter(ConsolePrinter(), LOG_LEVEL.DEBUG) if log_printer is None
+        else log_printer)
 
     exitcode = 0
     results = {}

--- a/coalib/misc/Exceptions.py
+++ b/coalib/misc/Exceptions.py
@@ -7,7 +7,8 @@ from pkg_resources import VersionConflict
 
 
 def get_exitcode(exception, log_printer=None):
-    log_printer = log_printer or LogPrinter(NullPrinter())
+    log_printer = (LogPrinter(NullPrinter()) if log_printer is None
+                   else log_printer)
 
     if isinstance(exception, KeyboardInterrupt):  # Ctrl+C
         print("Program terminated by user.")

--- a/coalib/output/ConfWriter.py
+++ b/coalib/output/ConfWriter.py
@@ -1,4 +1,5 @@
 from itertools import chain
+from types import MappingProxyType
 
 from pyprint.ClosableObject import ClosableObject
 
@@ -13,12 +14,9 @@ class ConfWriter(ClosableObject):
                  key_value_delimiters=('=',),
                  comment_separators=('#',),
                  key_delimiters=(',', ' '),
-                 section_name_surroundings=None,
+                 section_name_surroundings=MappingProxyType({"[": "]"}),
                  section_override_delimiters=(".",),
                  unsavable_keys=("save",)):
-        section_name_surroundings = (
-            {"[": "]"} if section_name_surroundings is None
-            else section_name_surroundings)
         ClosableObject.__init__(self)
         self.__file_name = file_name
         self.__file = open(self.__file_name, "w")

--- a/coalib/output/ConfWriter.py
+++ b/coalib/output/ConfWriter.py
@@ -16,7 +16,9 @@ class ConfWriter(ClosableObject):
                  section_name_surroundings=None,
                  section_override_delimiters=(".",),
                  unsavable_keys=("save",)):
-        section_name_surroundings = section_name_surroundings or {"[": "]"}
+        section_name_surroundings = (
+            {"[": "]"} if section_name_surroundings is None
+            else section_name_surroundings)
         ClosableObject.__init__(self)
         self.__file_name = file_name
         self.__file = open(self.__file_name, "w")

--- a/coalib/output/ConsoleInteraction.py
+++ b/coalib/output/ConsoleInteraction.py
@@ -91,7 +91,7 @@ def acquire_actions_and_apply(console_printer,
                             key.
     :param cli_actions:     The list of cli actions available.
     """
-    cli_actions = cli_actions or CLI_ACTIONS
+    cli_actions = CLI_ACTIONS if cli_actions is None else cli_actions
     failed_actions = set()
     while True:
         actions = []

--- a/coalib/parsing/CliParsing.py
+++ b/coalib/parsing/CliParsing.py
@@ -38,7 +38,7 @@ def parse_cli(arg_list=None,
     # Note: arg_list can also be []. Hence we cannot use
     # `arg_list = arg_list or default_list`
     arg_list = sys.argv[1:] if arg_list is None else arg_list
-    arg_parser = arg_parser or default_arg_parser()
+    arg_parser = default_arg_parser() if arg_parser is None else arg_parser
     origin += os.path.sep
     sections = OrderedDict(default=Section('Default'))
     line_parser = LineParser(key_value_delimiters,

--- a/coalib/parsing/ConfParser.py
+++ b/coalib/parsing/ConfParser.py
@@ -1,5 +1,6 @@
 import os
 from collections import OrderedDict
+from types import MappingProxyType
 
 from coalib.misc import Constants
 from coalib.parsing.LineParser import LineParser
@@ -13,12 +14,8 @@ class ConfParser:
                  key_value_delimiters=('=',),
                  comment_seperators=('#',),
                  key_delimiters=(',', ' '),
-                 section_name_surroundings=None,
+                 section_name_surroundings=MappingProxyType({"[": "]"}),
                  remove_empty_iter_elements=True):
-        section_name_surroundings = (
-            {"[": "]"} if section_name_surroundings is None
-            else section_name_surroundings)
-
         self.line_parser = LineParser(key_value_delimiters,
                                       comment_seperators,
                                       key_delimiters,

--- a/coalib/parsing/ConfParser.py
+++ b/coalib/parsing/ConfParser.py
@@ -15,7 +15,9 @@ class ConfParser:
                  key_delimiters=(',', ' '),
                  section_name_surroundings=None,
                  remove_empty_iter_elements=True):
-        section_name_surroundings = section_name_surroundings or {"[": "]"}
+        section_name_surroundings = (
+            {"[": "]"} if section_name_surroundings is None
+            else section_name_surroundings)
 
         self.line_parser = LineParser(key_value_delimiters,
                                       comment_seperators,

--- a/coalib/parsing/DefaultArgParser.py
+++ b/coalib/parsing/DefaultArgParser.py
@@ -29,7 +29,8 @@ def default_arg_parser(formatter_class=None):
     :param formatter_class: Formatting the arg_parser output into a specific
                             form. For example: In the manpage format.
     """
-    formatter_class = formatter_class or CustomFormatter
+    formatter_class = (CustomFormatter if formatter_class is None
+                       else formatter_class)
 
     entry_point = sys.argv[0]
     for entry in ['coala-ci', 'coala-dbus', 'coala-format', 'coala-json',

--- a/coalib/parsing/LineParser.py
+++ b/coalib/parsing/LineParser.py
@@ -30,7 +30,9 @@ class LineParser:
                                             "section" despite of the current
                                             section.
         """
-        section_name_surroundings = section_name_surroundings or {"[": "]"}
+        section_name_surroundings = (
+            {"[": "]"} if section_name_surroundings is None
+            else section_name_surroundings)
 
         self.key_value_delimiters = key_value_delimiters
         self.comment_separators = comment_separators

--- a/coalib/processes/communication/LogMessage.py
+++ b/coalib/processes/communication/LogMessage.py
@@ -19,7 +19,7 @@ class LogMessage:
             raise ValueError("Empty log messages are not allowed.")
 
         self.log_level = log_level
-        self.timestamp = timestamp or datetime.today()
+        self.timestamp = datetime.today() if timestamp is None else timestamp
 
     def __str__(self):
         log_level = LOG_LEVEL.reverse.get(self.log_level, "ERROR")

--- a/coalib/results/TextRange.py
+++ b/coalib/results/TextRange.py
@@ -27,7 +27,7 @@ class TextRange:
         """
 
         self._start = start
-        self._end = end or copy.deepcopy(start)
+        self._end = copy.deepcopy(start) if end is None else end
 
         if self._end < start:
             raise ValueError("End position can't be less than start position.")
@@ -104,10 +104,11 @@ class TextRange:
         :param text_lines: File contents of the applicable file
         :return:           TextRange with absolute values
         """
-        start_line = self.start.line or 1
-        start_column = self.start.column or 1
-        end_line = self.end.line or len(text_lines)
-        end_column = self.end.column or len(text_lines[end_line - 1])
+        start_line = 1 if self.start.line is None else self.start.line
+        start_column = 1 if self.start.column is None else self.start.column
+        end_line = len(text_lines) if self.end.line is None else self.end.line
+        end_column = (len(text_lines[end_line - 1]) if self.end.column is None
+                      else self.end.column)
 
         return TextRange.from_values(start_line,
                                      start_column,

--- a/coalib/settings/FunctionMetadata.py
+++ b/coalib/settings/FunctionMetadata.py
@@ -151,8 +151,8 @@ class FunctionMetadata:
         optional_params = OrderedDict()
 
         argspec = getfullargspec(func)
-        args = argspec.args or ()
-        defaults = argspec.defaults or ()
+        args = () if argspec.args is None else argspec.args
+        defaults = () if argspec.defaults is None else argspec.defaults
         num_non_defaults = len(args) - len(defaults)
         for i, arg in enumerate(args):
             # Implicit self argument or omitted explicitly


### PR DESCRIPTION
Does not replace or in line 30 of
coalib/bearlib/languages/LanguageDefinition.py and
in line 139 of
coalib/bearlib/langugaes/documentation/DocstyleDefinition.py
because for any empty case of coalang_dir, we need the other one
and not the empty case.

Also does not replace whenever x is boolean.

Fixes https://github.com/coala-analyzer/coala/issues/1544