### PR TITLE
Fix range docstrings

### DIFF
--- a/coalib/results/SourceRange.py
+++ b/coalib/results/SourceRange.py
@@ -21,8 +21,9 @@ class SourceRange(TextRange):
                             here. end must be in the same file and be greater
                             than start as negative ranges are not allowed.
         :raises TypeError:  Raised when
-                            - start is no SourcePosition or None.
-                            - end is no SourcePosition.
+                            - start is not of type SourcePosition.
+                            - end is neither of type SourcePosition, nor is it
+                              None.
         :raises ValueError: Raised when file of start and end mismatch.
         """
         TextRange.__init__(self, start, end)

--- a/coalib/results/TextRange.py
+++ b/coalib/results/TextRange.py
@@ -20,8 +20,9 @@ class TextRange:
                             ``None`` is given, the start object will be used
                             here.
         :raises TypeError:  Raised when
-                            - start is no TextPosition or None.
-                            - end is no TextPosition.
+                            - start is not of type TextPosition.
+                            - end is neither of type TextPosition, nor is it
+                              None.
         :raises ValueError: Raised when end position is smaller than start
                             position, because negative ranges are not allowed.
         """


### PR DESCRIPTION
Addresses #1963. Also fixes the docstring for `TextRange`, which had the same problem.