### PR TITLE
Writing_Bears.rst: Correct code example

### DIFF
--- a/docs/Users/Tutorials/Writing_Bears.rst
+++ b/docs/Users/Tutorials/Writing_Bears.rst
@@ -108,7 +108,6 @@ the creative name CommunicationBear:
                 type=type(user_input)))
 
             yield self.new_result(message="A hello world result.",
-                                  origin=self,
                                   file=filename)
 
 Try executing it:


### PR DESCRIPTION
`self.new_result()` inside `run()` already takes over the `origin=self`
part, that was the whole purpose of this function.

As this is quite important, I just took this over myself :3