### PR TITLE
Updated the spelling for successfully in lint.py

### DIFF
--- a/coalib/bearlib/abstractions/Lint.py
+++ b/coalib/bearlib/abstractions/Lint.py
@@ -292,7 +292,7 @@ class Lint(Bear):
                                   command: (list, tuple, None), fail_msg):
         """
         Checks whether the required executable is found and the
-        required command succesfully executes.
+        required command successfully executes.
 
         The function is intended be used with classes having an
         executable, prerequisite_command and prerequisite_fail_msg.


### PR DESCRIPTION
Updated the spelling for "succesfully" to "successfully" as per issue - https://github.com/coala-analyzer/coala/issues/2478