### PR TITLE
Fixed typo in Install.rst

### DIFF
--- a/docs/Users/Install.rst
+++ b/docs/Users/Install.rst
@@ -157,7 +157,7 @@ that doesn't support our version specifiers yet.
     ::
 
         $ pip3 install virtualenv
-        $ virtualenv -p python3 ~/venvs/coala
+        $ virtualenv -p python3 ~/venv/coala
         $ . ~/venv/coala/bin/activate
         $ pip install -U pip
         $ pip install coala-bears


### PR DESCRIPTION
A typo was fixed in the file docs/Users/Install.rst. A word was changed from
"venvs" to "venv"

Fixes issue https://github.com/coala-analyzer/coala/issues/2587