### PR TITLE
Tutorial: Added --show-description to --show-bears

### DIFF
--- a/docs/Users/Tutorials/Tutorial.rst
+++ b/docs/Users/Tutorials/Tutorial.rst
@@ -342,7 +342,7 @@ To get help on using a bear or to get a description of the bear, use the
 
 ::
 
-    coala --bears=SpaceConsistencyBear --show-bears
+    coala --bears=SpaceConsistencyBear --show-bears --show-description
 
 This will display a large amount of information regarding the bears that
 have been specified (in the ``.coafile`` of in the CLI arguments). It

--- a/docs/Users/Tutorials/Writing_Bears.rst
+++ b/docs/Users/Tutorials/Writing_Bears.rst
@@ -137,7 +137,7 @@ Try executing
 
 ::
 
-    coala -d bears -b CommunicationBear --show-bears
+    coala -d bears -b CommunicationBear --show-bears --show-description
 
 This will show the user a bunch of information related to the bear like:
 - A description of what the bear does - The sections which uses it - The


### PR DESCRIPTION
The Tutorial.rst and Writing_Bears.rst files didn't include the
--show-description flags. Without them it shows a list of the Bears
without the full descriptions as spoken about in the tutorial.

Closes https://github.com/coala-analyzer/coala/issues/2528