### PR TITLE
Parser: Fix instances of "touples"

### DIFF
--- a/coalib/parsing/CliParsing.py
+++ b/coalib/parsing/CliParsing.py
@@ -80,13 +80,13 @@ def parse_custom_settings(sections,
     :param line_parser:          The LineParser to use.
     """
     for setting_definition in custom_settings_list:
-        (_, key_touples, value, _) = line_parser.parse(setting_definition)
-        for key_touple in key_touples:
+        (_, key_tuples, value, _) = line_parser.parse(setting_definition)
+        for key_tuple in key_tuples:
             append_to_sections(sections,
-                               key=key_touple[1],
+                               key=key_tuple[1],
                                value=value,
                                origin=origin,
-                               section_name=key_touple[0],
+                               section_name=key_tuple[0],
                                from_cli=True)
 
 

--- a/coalib/parsing/LineParser.py
+++ b/coalib/parsing/LineParser.py
@@ -44,7 +44,7 @@ class LineParser:
 
     def parse(self, line):
         """
-        Note that every value in the returned touple *besides the value* is
+        Note that every value in the returned tuple *besides the value* is
         unescaped. This is so since the value is meant to be put into a Setting
         later thus the escapes may be needed there.
 
@@ -80,7 +80,7 @@ class LineParser:
 
         value = convert_to_raw(value, all_delimiters)
 
-        key_touples = []
+        key_tuples = []
         for key in keys:
             key = convert_to_raw(key, all_delimiters)
             section, key = self.__separate_by_first_occurrence(
@@ -88,9 +88,9 @@ class LineParser:
                 self.section_override_delimiters,
                 True,
                 True)
-            key_touples.append((unescape(section), unescape(key)))
+            key_tuples.append((unescape(section), unescape(key)))
 
-        return '', key_touples, value, comment
+        return '', key_tuples, value, comment
 
     @staticmethod
     def __separate_by_first_occurrence(string,
@@ -108,7 +108,7 @@ class LineParser:
         :param return_second_part_nonempty: If no delimiter is found and this
                                             is true the contents of the string
                                             will be returned in the second part
-                                            of the touple instead of the first
+                                            of the tuple instead of the first
                                             one.
         :return:                            (first_part, second_part)
         """


### PR DESCRIPTION
Replace every mention of "touples" with "tuple." This affects both
comments and named variables, but doesn't affect functionality.

Closes https://github.com/coala-analyzer/coala/issues/2412