### PR TITLE
CliParsing.py: Remove arg_list assignment

### DIFF
--- a/coalib/parsing/CliParsing.py
+++ b/coalib/parsing/CliParsing.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from argparse import ArgumentParser
 from collections import OrderedDict
 
@@ -35,9 +34,6 @@ def parse_cli(arg_list=None,
                                         as keys and the sections themselves
                                         as value.
     """
-    # Note: arg_list can also be []. Hence we cannot use
-    # `arg_list = arg_list or default_list`
-    arg_list = sys.argv[1:] if arg_list is None else arg_list
     arg_parser = default_arg_parser() if arg_parser is None else arg_parser
     origin += os.path.sep
     sections = OrderedDict(default=Section('Default'))


### PR DESCRIPTION
Removes an unneeded assignment of arg_list in parse_cli.
Because parse_args uses sys.argv as default, we don't need to
assign it beforehand if none is given.

Closes https://github.com/coala-analyzer/coala/issues/2170