### PR TITLE
Improve warning message

### DIFF
--- a/coalib/collecting/Collectors.py
+++ b/coalib/collecting/Collectors.py
@@ -170,7 +170,9 @@ def collect_bears(bear_dirs, bear_globs, kinds, log_printer,
 
     if warn_if_unused_glob:
         _warn_if_unused_glob(log_printer, bear_globs, bear_globs_with_bears,
-                             "No bears were found matching '{}'.")
+                             "No bears were found matching '{}'. Make sure you "
+                             "have coala-bears installed or you have typed the "
+                             "name correctly.")
     return bears_found
 
 

--- a/tests/collecting/CollectorsTest.py
+++ b/tests/collecting/CollectorsTest.py
@@ -214,8 +214,10 @@ class CollectBearsTest(unittest.TestCase):
                                            ["invalid kind"],
                                            self.log_printer), ([],))
             self.assertRegex(sio.getvalue(),
-                             ".*\\[WARNING\\].*No bears were found matching "
-                             "'invalid_name'.\n")
+                             ".*\\[WARNING\\].*No bears were found "
+                             "matching 'invalid_name'. Make sure you "
+                             "have coala-bears installed or you have "
+                             "typed the name correctly.\n")
 
         self.assertEqual(collect_bears(["invalid_paths"],
                                        ["invalid_name"],


### PR DESCRIPTION
Improves the warning message when the user prompts to run a
bear and no matching bears are found.

Closes https://github.com/coala-analyzer/coala/issues/2402