### PR TITLE
Caching: Compute hash only for enabled sections

### DIFF
--- a/coalib/coala_main.py
+++ b/coalib/coala_main.py
@@ -77,7 +77,7 @@ def run_coala(log_printer=None,
 
         config_file = os.path.abspath(str(sections["default"].get("config")))
 
-        settings_hash = get_settings_hash(sections)
+        settings_hash = get_settings_hash(sections, targets)
         flush_cache = bool(sections["default"].get("flush_cache", False) or
                            settings_changed(log_printer, settings_hash))
 

--- a/coalib/misc/CachingUtilities.py
+++ b/coalib/misc/CachingUtilities.py
@@ -128,22 +128,26 @@ def hash_id(text):
     return hashlib.md5(text.encode("utf-8")).hexdigest()
 
 
-def get_settings_hash(sections, ignore_settings: list=["disable_caching"]):
+def get_settings_hash(sections,
+                      targets=[],
+                      ignore_settings: list=["disable_caching"]):
     """
     Compute and return a unique hash for the settings.
 
     :param sections:        A dict containing the settings for each section.
+    :param targets:         The list of sections that are enabled.
     :param ignore_settings: Setting keys to remove from sections before
                             hashing.
     :return:                A MD5 hash that is unique to the settings used.
     """
     settings = []
     for section in sections:
-        section_copy = copy.deepcopy(sections[section])
-        for setting in ignore_settings:
-            if setting in section_copy:
-                section_copy.delete_setting(setting)
-        settings.append(str(section_copy))
+        if section in targets or targets == []:
+            section_copy = copy.deepcopy(sections[section])
+            for setting in ignore_settings:
+                if setting in section_copy:
+                    section_copy.delete_setting(setting)
+            settings.append(str(section_copy))
 
     return hash_id(str(settings))
 

--- a/tests/misc/CachingUtilitiesTest.py
+++ b/tests/misc/CachingUtilitiesTest.py
@@ -65,3 +65,8 @@ class SettingsTest(unittest.TestCase):
         sections = {"a": Section("a")}
         settings_hash = get_settings_hash(sections)
         self.assertTrue(settings_changed(self.log_printer, settings_hash))
+
+    def test_targets_change(self):
+        sections = {"a": Section("a"), "b": Section("b")}
+        self.assertNotEqual(get_settings_hash(sections),
+                            get_settings_hash(sections, targets=["a"]))


### PR DESCRIPTION
This will ensure a cache store flush when the list of sections
to run changes.

Fixes https://github.com/coala-analyzer/coala/issues/2708