### PR TITLE
Fix typo: ShowPatchAction.py: `Wether` -> `Whether`

### DIFF
--- a/coalib/results/result_actions/ShowPatchAction.py
+++ b/coalib/results/result_actions/ShowPatchAction.py
@@ -83,7 +83,7 @@ class ShowPatchAction(ResultAction):
         '''
         Print a diff of the patch that would be applied.
 
-        :param colored: Wether or not to use colored output.
+        :param colored: Whether or not to use colored output.
         '''
         printer = ConsolePrinter(colored)
 


### PR DESCRIPTION
Fix typo: ShowPatchAction.py: `Wether` -> `Whether`