### PR TITLE
js.coalang: Move js.coalang file from languages folder to definitions subfolder

### DIFF
--- a/coalib/bearlib/languages/js.coalang
+++ b/coalib/bearlib/languages/js.coalang
@@ -1,7 +1,0 @@
-extensions = .js
-comment_delimiter = //
-multiline_comment_delimiters = /* : */
-string_delimiters = " : ", ' : '
-multiline_string_delimiters = 
-indent_types = { : }
-encapsulators = ( : ), [ : ]


### PR DESCRIPTION
js.coalang is a language definition file and thus is to be placed in definitions folder where definitions of other languages reside as well.

Fixes https://github.com/coala-analyzer/coala/issues/2723