### PR TITLE
Keep existing tab instead of adding a space

### DIFF
--- a/coalib/bearlib/spacing/SpacingHelper.py
+++ b/coalib/bearlib/spacing/SpacingHelper.py
@@ -107,11 +107,11 @@ class SpacingHelper(SectionCreatable):
 
             # tabless_position is now incremented to point _after_ the current
             # char
-            if tabless_position % self.tab_width == 0:
-                if currspaces > 1:
-                    result += "\t"
+            if tabless_position % self.tab_width == 0 and currspaces:
+                if currspaces == 1 and char == " ":
+                    result += " "
                 else:
-                    result += currspaces*" "
+                    result += "\t"
 
                 currspaces = 0
 

--- a/tests/bearlib/spacing/SpacingHelperTest.py
+++ b/tests/bearlib/spacing/SpacingHelperTest.py
@@ -87,4 +87,5 @@ class SpacingHelperTest(unittest.TestCase):
         self.assertEqual(
             self.uut.replace_spaces_with_tabs(" \t   a_text   another"),
             "\t   a_text\tanother")
+        self.assertEqual(self.uut.replace_spaces_with_tabs("123\t"), "123\t")
         self.assertEqual(self.uut.replace_spaces_with_tabs("d  d"), "d  d")


### PR DESCRIPTION
When converting spaces to tabs, spaces are being randomly added.
Use the existing tab, even when a space would be sufficient.